### PR TITLE
Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,10 @@
 {
 	"name": "Chat with your data",
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
 	"features": {
 		"ghcr.io/devcontainers/features/azure-cli:1": {},
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/node:1" : {},
 		"ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {},
 		"rchaganti/vsc-devcontainer-features/azurebicep" : {
 			"version": "latest"


### PR DESCRIPTION
added missing node feature and mismatch python version to fix problems with pip install and npm install

## Purpose
Python version 3.12 breaks pip install for some of the deps in the requirements.txt. Downgrade to match docker image versions 3.11 fixes the issues. 
The devcontainer is also missing node feature, which is required for npm install for the frontend.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
create and run the devcontainer and run:
cd code && python -m pip install -r requirements.txt 
cd app && python -m pip install -r requirements.txt 
cd frontend && npm install

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->