### PR TITLE
Update deployment.json

### DIFF
--- a/infrastructure/deployment.json
+++ b/infrastructure/deployment.json
@@ -263,7 +263,7 @@
     },
     "StorageAccountName": {
       "type": "string",
-      "defaultValue": "[substring(format('{0}str{1}', parameters('ResourcePrefix'), uniqueString(resourceGroup().id)), 0, 24)]",
+      "defaultValue": "[take(format('{0}str{1}', parameters('ResourcePrefix'), uniqueString(resourceGroup().id)), 24)]",
       "metadata": {
         "description": "Name of Storage Account"
       }


### PR DESCRIPTION
fix bug when ResourcePrefix + resourceGroup().id is less than 24 chars, using take instead of substring

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- go to [anddan1106-deploy branch]( https://github.com/anddan1106/chat-with-your-data-solution-accelerator/tree/anddan1106-deploy)
- click deploy from readme
- assign Resource Prefix to a string of 4 chars
- assign values non optional fields
- validate the deployment

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* no validation error should be thrown

## Other Information
substring("string", 0, 24) require a string length of 24 or more, and will always return 24 chars. 
take("string", 24) will return at most 24 chars, otherwise original string will be returned