### PR TITLE
Fix teams deployment link

### DIFF
--- a/docs/TEAMS_EXTENSION.md
+++ b/docs/TEAMS_EXTENSION.md
@@ -25,7 +25,7 @@ This extension enables users to experience Chat with your data within Teams, wit
 
 ### Deploy backend Azure Function
 <!-- TODO: Updated prior to PR -->
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%Azure-Samples%2Fchat-with-your-data-solution-accelerator%2Fmain%2Fextensions%2Finfrastructure%2Fmain.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure-Samples%2Fchat-with-your-data-solution-accelerator%2Fmain%2Fextensions%2Finfrastructure%2Fmain.json)
 
 Note: The (p) suffix on the App Setting (below) means that you should use the same resources and services deployed during the [Chat with your data with speech-to-text deployment](../README.md)
 


### PR DESCRIPTION
## Purpose
The current link is broken. This commit fixes it by correctly encoding the `/` character in the link.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

```
Visit the url for the updated button link
```

## What to Check
Verify that the following are valid
* The azure custom deployment form is correctly populated

