### PR TITLE
Update docker images to use same python version

### DIFF
--- a/docker/AdminWebApp.Dockerfile
+++ b/docker/AdminWebApp.Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.9.10-slim-buster
-RUN apt-get update && apt-get install python-tk python3-tk tk-dev -y
+FROM python:3.11.7-bookworm
+# RUN apt-get update && apt-get install python-tk python3-tk tk-dev -y
+RUN apt-get update && apt-get install python3-tk tk-dev -y
 COPY ./code/requirements.txt /usr/local/src/myscripts/requirements.txt
 WORKDIR /usr/local/src/myscripts
 RUN pip install -r requirements.txt

--- a/docker/AdminWebApp.Dockerfile
+++ b/docker/AdminWebApp.Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3.11.7-bookworm
-# RUN apt-get update && apt-get install python-tk python3-tk tk-dev -y
 RUN apt-get update && apt-get install python3-tk tk-dev -y
 COPY ./code/requirements.txt /usr/local/src/myscripts/requirements.txt
 WORKDIR /usr/local/src/myscripts

--- a/docker/Backend.Dockerfile
+++ b/docker/Backend.Dockerfile
@@ -1,6 +1,6 @@
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/python:4-python3.9-appservice
-FROM mcr.microsoft.com/azure-functions/python:4-python3.10
+FROM mcr.microsoft.com/azure-functions/python:4-python3.11
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true \

--- a/docker/WebApp.Dockerfile
+++ b/docker/WebApp.Dockerfile
@@ -9,7 +9,7 @@ COPY --chown=node:node ./code/app/frontend ./frontend
 WORKDIR /home/node/app/frontend
 RUN npm run build
   
-FROM python:3.9.7-alpine3.14  
+FROM python:3.11.7-alpine3.19  
 RUN apk add --no-cache --virtual .build-deps \  
     build-base \  
     libffi-dev \  


### PR DESCRIPTION
## Purpose
- align on the latest python 3.11 version
  - there is no 3.12 version for `mcr.microsoft.com/azure-functions/python`
- bump to bookworm arch in admin image
- remove `python-tk` installation as it's no longer present, nor does it seem to be required


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe:
```
