### PR TITLE
Set PYTHONPATH env var in admin app

### DIFF
--- a/docker/AdminWebApp.Dockerfile
+++ b/docker/AdminWebApp.Dockerfile
@@ -6,5 +6,6 @@ RUN pip install -r requirements.txt
 COPY ./code/admin /usr/local/src/myscripts/admin
 COPY ./code/utilities /usr/local/src/myscripts/utilities
 WORKDIR /usr/local/src/myscripts/admin
+ENV PYTHONPATH "${PYTHONPATH}:/usr/local/src/myscripts"
 EXPOSE 80
 CMD ["streamlit", "run", "Admin.py", "--server.port", "80", "--server.enableXsrfProtection", "false"]


### PR DESCRIPTION
## Purpose
- Set it to the root of the code dir `/usr/local/src`
- This fixes an issue where you get a MissingModule error after a restart of the application

Fixes https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/issues/87

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
1. Rebuild admin image and deploy new version
2. Navigate to a non-homepage page
3. Restart the application
4. Restart the page
```
