### PR TITLE
Fix duplicate copy warning alert

### DIFF
--- a/code/app/frontend/src/components/Answer/Answer.tsx
+++ b/code/app/frontend/src/components/Answer/Answer.tsx
@@ -14,11 +14,13 @@ import supersub from 'remark-supersub'
 interface Props {
     answer: AskResponse;
     onCitationClicked: (citedDocument: Citation) => void;
+    index: Number;
 }
 
 export const Answer = ({
     answer,
-    onCitationClicked
+    onCitationClicked,
+    index,
 }: Props) => {
     const [isRefAccordionOpen, { toggle: toggleIsRefAccordionOpen }] = useBoolean(false);
     const filePathTruncationLimit = 50;
@@ -57,15 +59,16 @@ export const Answer = ({
         const handleCopy = () => {
             alert("Please consider where you paste this content.");
         };
-        document.addEventListener("copy", handleCopy);
+        var messageBox = document.getElementById("message-" + index);
+        messageBox?.addEventListener("copy", handleCopy);
         return () => {
-            document.removeEventListener("copy", handleCopy);
+            messageBox?.removeEventListener("copy", handleCopy);
         };
     }, []);
 
     return (
         <>
-            <Stack className={styles.answerContainer}>
+            <Stack className={styles.answerContainer} id={"message-" + index}>
                 <Stack.Item grow>
                     <ReactMarkdown
                         remarkPlugins={[remarkGfm, supersub]}

--- a/code/app/frontend/src/components/Answer/Answer.tsx
+++ b/code/app/frontend/src/components/Answer/Answer.tsx
@@ -14,7 +14,7 @@ import supersub from 'remark-supersub'
 interface Props {
     answer: AskResponse;
     onCitationClicked: (citedDocument: Citation) => void;
-    index: Number;
+    index: number;
 }
 
 export const Answer = ({
@@ -24,6 +24,8 @@ export const Answer = ({
 }: Props) => {
     const [isRefAccordionOpen, { toggle: toggleIsRefAccordionOpen }] = useBoolean(false);
     const filePathTruncationLimit = 50;
+
+    const messageBoxId = "message-" + index;
 
     const parsedAnswer = useMemo(() => parseAnswer(answer), [answer]);
     const [chevronIsExpanded, setChevronIsExpanded] = useState(isRefAccordionOpen);
@@ -59,7 +61,7 @@ export const Answer = ({
         const handleCopy = () => {
             alert("Please consider where you paste this content.");
         };
-        var messageBox = document.getElementById("message-" + index);
+        const messageBox = document.getElementById(messageBoxId);
         messageBox?.addEventListener("copy", handleCopy);
         return () => {
             messageBox?.removeEventListener("copy", handleCopy);
@@ -68,7 +70,7 @@ export const Answer = ({
 
     return (
         <>
-            <Stack className={styles.answerContainer} id={"message-" + index}>
+            <Stack className={styles.answerContainer} id={messageBoxId}>
                 <Stack.Item grow>
                     <ReactMarkdown
                         remarkPlugins={[remarkGfm, supersub]}

--- a/code/app/frontend/src/pages/chat/Chat.tsx
+++ b/code/app/frontend/src/pages/chat/Chat.tsx
@@ -302,6 +302,7 @@ const Chat = () => {
                               : [],
                         }}
                         onCitationClicked={(c) => onShowCitation(c)}
+                        index={index}
                       />
                     </div>
                   ) : null}


### PR DESCRIPTION
## Purpose
- It was being added to the whole page everytime an answer was returned
- This meant that if **any** content on the page was copied the alert was being shown multiple times based on how many answers there had been
- This change will mean the alert will now only be shown when an answer is copied and only once

Required by https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/issues/215

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->