### PR TITLE
Only deploy the accelerator on a push to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 50
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 50

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  workflow_dispatch:
-  pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
## Purpose
Current build is triggered during Pull Request. When this occurs on a forked branch, the user will not have access to the secrets and the deployment will fail

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
CI only runs on push to main for the moment.