### PR TITLE
Orchestration Strategy

### DIFF
--- a/code/backend/batch/utilities/helpers/ConfigHelper.py
+++ b/code/backend/batch/utilities/helpers/ConfigHelper.py
@@ -88,6 +88,7 @@ class ConfigHelper:
 
     @staticmethod
     def get_default_config():
+        env_helper = EnvHelper()
         default_config = {
             "prompts": {
                 "condense_question_prompt": """Given the following conversation and a follow up question, rephrase the follow up question to be a standalone question. If the user asks multiple questions at once, break them up into multiple standalone questions, all in one line.
@@ -204,6 +205,6 @@ Answer: {answer}""",
                 },
             ],
             "logging": {"log_user_interactions": True, "log_tokens": True},
-            "orchestrator": {"strategy": "openai_function"},
+            "orchestrator": {"strategy": env_helper.ORCHESTRATION_STRATEGY},
         }
         return Config(default_config)

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -753,3 +753,4 @@ output AZURE_SEARCH_KEY string = useKeyVault ? storekeys.outputs.SEARCH_KEY_NAME
 output AZURE_CONTENT_SAFETY_KEY string = useKeyVault ? storekeys.outputs.CONTENT_SAFETY_KEY_NAME : ''
 output AZURE_SPEECH_SERVICE_REGION string = location
 output AZURE_SPEECH_SERVICE_KEY string = useKeyVault ? storekeys.outputs.SPEECH_KEY_NAME : ''
+output ORCHESTRATION_STRATEGY string = orchestrationStrategy

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.25.53.49325",
-      "templateHash": "11044000718103660256"
+      "templateHash": "709162983947072789"
     }
   },
   "parameters": {
@@ -6635,6 +6635,10 @@
     "AZURE_SPEECH_SERVICE_KEY": {
       "type": "string",
       "value": "[if(parameters('useKeyVault'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('rgName')), 'Microsoft.Resources/deployments', 'storekeys'), '2022-09-01').outputs.SPEECH_KEY_NAME.value, '')]"
+    },
+    "ORCHESTRATION_STRATEGY": {
+      "type": "string",
+      "value": "[parameters('orchestrationStrategy')]"
     }
   }
 }


### PR DESCRIPTION
## Purpose
The Orchestration Strategy is set in the bicep when the infrastructure is created. That value is set in the App Settings of the Web Apps. However, it was not being set as an output of the bicep. This means when you debug things locally, it is using the default of "openai_function" even if you set it as langchain.

Also when you set up a default configuration from the Admin page, then it was hardcoded to be openai_function. This change will use whatever was configured at initial setup.

You can still change this value and save the settings. It stores this in the `config` container in Azure Storage

Fixes #56

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Build the infratsructure and set ORCHESTRATION_STRATEGY
* Go to the Admin Page and check that it is selected in the first drop down box
* Save it and check that this is written to the Storage