### PR TITLE
Add coverage to PRs

### DIFF
--- a/.github/workflows/comment_coverage.yml
+++ b/.github/workflows/comment_coverage.yml
@@ -1,0 +1,31 @@
+name: Comment coverage
+
+on:
+  workflow_run:
+    workflows: [Tests]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Comment coverage
+    runs-on: ubuntu-20.04
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Comment coverage
+        uses: MishaKav/pytest-coverage-comment@a1fe18e2b00c64a765568e2edb9f1706eb8fc88b
+        with:
+          pytest-xml-coverage-path: coverage.xml
+          junitxml-path: coverage-junit.xml
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/comment_coverage.yml
+++ b/.github/workflows/comment_coverage.yml
@@ -29,3 +29,5 @@ jobs:
           pytest-xml-coverage-path: coverage.xml
           junitxml-path: coverage-junit.xml
           issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          coverage-path-prefix: code/
+          report-only-changed-files: true

--- a/.github/workflows/comment_coverage.yml
+++ b/.github/workflows/comment_coverage.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   comment:
     name: Comment coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
           pip install -r code/requirements.txt -r code/dev-requirements.txt -r code/backend/requirements.txt
       - name: Run Unit tests
         working-directory: ./code
-        run: python -m pytest -m "not azure and not functional" --junitxml=coverage-junit.xml --cov --cov-report xml:coverage.xml
+        run: python -m pytest -m "not azure and not functional" --junitxml=coverage-junit.xml --cov=. --cov-report xml:coverage.xml
       - uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   test_package:
     name: Tests
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,14 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
   workflow_call:
 
 jobs:
@@ -12,18 +17,27 @@ jobs:
     name: Tests
     runs-on: "ubuntu-20.04"
     steps:
-        - uses: actions/checkout@v4
-        - name: Setup python
-          uses: actions/setup-python@v5
-          with:
-            python-version: "3.11"
-            architecture: x64
-        - name: Install dependencies
-          run: |
-            pip install -r code/requirements.txt -r code/dev-requirements.txt -r code/backend/requirements.txt
-        - name: Run Unit tests
-          working-directory: ./code
-          run: python -m pytest -m "not azure and not functional"
-        - name: Run Functional tests
-          working-directory: ./code
-          run: python -m pytest -m "functional"
+      - uses: actions/checkout@v4
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          architecture: x64
+          cache: pip
+          cache-dependency-path: "**/*requirements*.txt"
+      - name: Install dependencies
+        run: |
+          pip install -r code/requirements.txt -r code/dev-requirements.txt -r code/backend/requirements.txt
+      - name: Run Unit tests
+        working-directory: ./code
+        run: python -m pytest -m "not azure and not functional" --junitxml=junit-coverage.xml --cov --cov-report xml:coverage.xml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: |
+            code/coverage-junit.xml
+            code/coverage.xml
+          if-no-files-found: error
+      - name: Run Functional tests
+        working-directory: ./code
+        run: python -m pytest -m "functional"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
           pip install -r code/requirements.txt -r code/dev-requirements.txt -r code/backend/requirements.txt
       - name: Run Unit tests
         working-directory: ./code
-        run: python -m pytest -m "not azure and not functional" --junitxml=junit-coverage.xml --cov --cov-report xml:coverage.xml
+        run: python -m pytest -m "not azure and not functional" --junitxml=coverage-junit.xml --cov --cov-report xml:coverage.xml
       - uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/code/.coveragerc
+++ b/code/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+omit =
+    tests/*
+
+[report]
+skip_empty = true
+include_namespace_packages = true


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Required for #408 

This PR adds commenting to PRs with code coverage.

The commenting is done using a third-party GitHub action, [pytest-coverage-comment](https://github.com/marketplace/actions/pytest-coverage-comment). It is pinned to a specific Git SHA to prevent automatically picking up new changes to the repo which could potentially be malicious.

The commenting is handled in a separate workflow, as the token in the `Tests` workflow only has read-only permissions and cannot comment on PRs when running from forks. The separate workflow for commenting only has write permissions to pull requests, and no other permissions.

This commenting action does not have the ability to fail a run based on a threshold, therefore this will be introduced in a separate PR. The next PR will also handle commenting after test failures.

The PR also introduces caching of pip dependencies.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: CI
```

## How to Test
It is is difficult to test as it will only run after it has been merged. I have managed to test it in my own fork.

![image](https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/assets/60179183/3d8ebfad-4f3a-4c51-a2fa-5b5b3107d404)
![image](https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/assets/60179183/7ead4316-fc8e-4db4-a83b-51bfb11e2450)

