### PR TITLE
Allow the overriding of app config from functional tests

### DIFF
--- a/code/tests/functional/backend_api/app_config.py
+++ b/code/tests/functional/backend_api/app_config.py
@@ -1,0 +1,32 @@
+import os
+from typing import Any, Dict
+
+
+class AppConfig:
+    config: Dict[str, Any] = {
+        "AZURE_SPEECH_SERVICE_KEY": "some-azure-speech-service-key",
+        "AZURE_SPEECH_SERVICE_REGION": "some-azure-speech-service-region",
+    }
+
+    def __init__(self, config_overrides: Dict[str, Any] = {}) -> None:
+        self.config = self.config | config_overrides
+
+    def set(self, key: str, value: Any) -> None:
+        self.config[key] = value
+
+    def get(self, key: str) -> Any:
+        return self.config[key]
+
+    def get_all(self) -> Dict[str, Any]:
+        return self.config
+
+    def apply_to_environment(self) -> None:
+        for key, value in self.config.items():
+            if value is not None:
+                os.environ[key] = value
+            else:
+                os.environ.pop(key, None)
+
+    def remove_from_environment(self) -> None:
+        for key in self.config.keys():
+            os.environ.pop(key, None)

--- a/code/tests/functional/backend_api/conftest.py
+++ b/code/tests/functional/backend_api/conftest.py
@@ -4,6 +4,7 @@ import time
 import pytest
 import requests
 from app import app
+from tests.functional.backend_api.app_config import AppConfig
 
 
 @pytest.fixture(scope="module")
@@ -17,11 +18,18 @@ def app_url(app_port: int) -> int:
     return f"http://localhost:{app_port}"
 
 
+@pytest.fixture(scope="module")
+def app_config() -> AppConfig:
+    return AppConfig()
+
+
 @pytest.fixture(scope="module", autouse=True)
-def manage_app(app_port: int):
+def manage_app(app_port: int, app_config: AppConfig):
+    app_config.apply_to_environment()
     app_process = start_app(app_port)
     yield
     stop_app(app_process)
+    app_config.remove_from_environment()
 
 
 def start_app(port: int) -> Process:

--- a/code/tests/functional/backend_api/test_config.py
+++ b/code/tests/functional/backend_api/test_config.py
@@ -2,17 +2,19 @@ import json
 import pytest
 import requests
 
+from tests.functional.backend_api.app_config import AppConfig
+
 pytestmark = pytest.mark.functional
 
 
-def test_config_returned(app_url: str):
+def test_config_returned(app_url: str, app_config: AppConfig):
     # when
     response = requests.get(f"{app_url}/api/config")
 
     # then
     assert response.status_code == 200
     assert json.loads(response.text) == {
-        "azureSpeechKey": None,
-        "azureSpeechRegion": None,
+        "azureSpeechKey": app_config.get("AZURE_SPEECH_SERVICE_KEY"),
+        "azureSpeechRegion": app_config.get("AZURE_SPEECH_SERVICE_REGION"),
     }
     assert response.headers["Content-Type"] == "application/json"


### PR DESCRIPTION
- Ideally we wouldn't be setting actual environment vars
- The ideal solution would be to supply the config via a configuration file
or as startup parameters
- However, I've implemented this way for now to avoid any changes to the actual code

Required by https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/issues/420
