### PR TITLE
Fail build if coverage is too low

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,7 @@
 		"vscode": {
 			"extensions": [
 				"github.vscode-pull-request-github",
+				"github.vscode-github-actions",
 				"ms-azuretools.azure-dev",
 				"ms-azuretools.vscode-azurefunctions",
 				"ms-azuretools.vscode-bicep",

--- a/.github/workflows/comment_coverage.yml
+++ b/.github/workflows/comment_coverage.yml
@@ -23,11 +23,22 @@ jobs:
           name: coverage
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
+      - name: Find associated pull request
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const response = await github.rest.search.issuesAndPullRequests({
+              q: "repo:${{ github.repository }} is:pr sha:${{ github.event.workflow_run.head_sha }}",
+              per_page: 1,
+            })
+
+            return response.data.items[0]?.number ?? "";
       - name: Comment coverage
         uses: MishaKav/pytest-coverage-comment@a1fe18e2b00c64a765568e2edb9f1706eb8fc88b
         with:
           pytest-xml-coverage-path: coverage.xml
           junitxml-path: coverage-junit.xml
-          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          issue-number: ${{ steps.pr.outputs.result }}
           coverage-path-prefix: code/
           report-only-changed-files: true

--- a/.github/workflows/comment_coverage.yml
+++ b/.github/workflows/comment_coverage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.conclusion != 'cancelled'
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/comment_coverage.yml
+++ b/.github/workflows/comment_coverage.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           script: |
             const response = await github.rest.search.issuesAndPullRequests({
-              q: "repo:${{ github.repository }} is:pr sha:${{ github.event.workflow_run.head_sha }}",
+              q: "repo:${{ github.repository }} is:pr is:open head:${{ github.event.workflow_run.head_branch }}",
               per_page: 1,
             })
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,9 @@ jobs:
               repo: context.repo.repo,
             });
 
-            const workflowId = workflows.data.workflows.find(workflow => workflow.name === "${{ github.workflow }}").id;
+            const workflowId = workflows.data.workflows.find(workflow => workflow.name === "${{ github.workflow }}")?.id;
+
+            if (!workflowId) return "";
 
             const workflowRuns = await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
@@ -49,18 +51,7 @@ jobs:
               status: "success",
             });
 
-            const workflowRunId = workflowRuns.data.workflow_runs[0]?.id;
-
-            if (!workflowRunId) return "";
-
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: workflowRunId,
-              name: "coverage",
-            });
-
-            return artifacts.data.artifacts[0]?.workflow_run.id ?? "";
+            return workflowRuns.data.workflow_runs[0]?.id ?? "";
           result-encoding: string
           retries: 3
       - name: Download main coverage artifact

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,66 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r code/requirements.txt -r code/dev-requirements.txt -r code/backend/requirements.txt
+      - name: Get coverage artifact ID
+        id: coverage-artifact
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const workflows = await github.rest.actions.listRepoWorkflows({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const workflowId = workflows.data.workflows.find(workflow => workflow.name === "${{ github.workflow }}").id;
+
+            const workflowRuns = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: workflowId,
+              branch: "${{ github.base_ref }}",
+              event: "push",
+              status: "success",
+            });
+
+            const workflowRunId = workflowRuns.data.workflow_runs[0]?.id;
+
+            if (!workflowRunId) return "";
+
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: workflowRunId,
+              name: "coverage",
+            });
+
+            return artifacts.data.artifacts[0]?.workflow_run.id ?? "";
+          result-encoding: string
+          retries: 3
+      - name: Download main coverage artifact
+        uses: actions/download-artifact@v4
+        if: steps.coverage-artifact.outputs.result != ''
+        continue-on-error: true # There is a chance that the artifact doesn't exist, or has expired
+        with:
+          name: coverage
+          path: "${{ github.workspace }}/coverage-main"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ steps.coverage-artifact.outputs.result }}
+      - name: Get coverage from main
+        id: coverage-value
+        run: |
+          MIN_COVERAGE=0
+
+          if [[ -f "./coverage-main/coverage.xml" ]]; then
+            MIN_COVERAGE=$(grep -m 1 "<coverage" "./coverage-main/coverage.xml" | sed -E 's/.*line-rate="([^"]*)".*/\1/') # Extract the line rate from the XML
+            MIN_COVERAGE=$(awk "BEGIN {print int($MIN_COVERAGE * 100)}") # Turn into percentage, rounding down to avoid rounding issues
+          fi
+
+          echo "MIN_COVERAGE=$MIN_COVERAGE" >> "$GITHUB_OUTPUT"
       - name: Run Unit tests
         working-directory: ./code
-        run: python -m pytest -m "not azure and not functional" --junitxml=coverage-junit.xml --cov=. --cov-report xml:coverage.xml
+        run: python -m pytest -m "not azure and not functional" --junitxml=coverage-junit.xml --cov=. --cov-report xml:coverage.xml --cov-fail-under ${{ steps.coverage-value.outputs.MIN_COVERAGE }}
       - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
         with:
           name: coverage
           path: |

--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,8 @@ coverage*.info
 *.coverage
 *.coveragexml
 
+coverage-main
+
 # NCrunch
 _NCrunch_*
 .*crunch*.local.xml


### PR DESCRIPTION
## Purpose
Closes #408 

This PR fails the build if the coverage is lower than the current coverage in the main branch. It does this by downloading the coverage artifact from the latest build of `main`, and extracting the coverage from the XML report. It then feeds this into the pytest command with the `--cov-fail-under` flag. If the coverage cannot be obtained from the main branch, it should default to 0.

The coverage from main is rounded down to the nearest integer, as the coverage obtained from main is usually to 2dp (e.g. 33.95%), while the coverage from pytest is to a much higher precision (33.948339483%), meaning that even if there were no changes to Python code, 33.948339483% < 33.95% would fail the build.

Also, this PR allows the coverage to be commented on the PR even if tests fail, and fixes bug when running from forks: https://github.com/orgs/community/discussions/25220.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: CI
```

## How to Test
I have tested this in my fork of this repo.

![image](https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/assets/60179183/3409c5d1-4a99-440d-9d0a-643f854141a0)
