### PR TITLE
Introduce functional test mock server

### DIFF
--- a/code/app.py
+++ b/code/app.py
@@ -36,6 +36,7 @@ def get_config():
         {
             "azureSpeechKey": env_helper.AZURE_SPEECH_KEY,
             "azureSpeechRegion": env_helper.AZURE_SPEECH_SERVICE_REGION,
+            "OPENAI_API_BASE": env_helper.OPENAI_API_BASE,
         }
     )
 

--- a/code/backend/batch/utilities/helpers/EnvHelper.py
+++ b/code/backend/batch/utilities/helpers/EnvHelper.py
@@ -104,16 +104,14 @@ class EnvHelper:
             self.AZURE_OPENAI_KEY = os.environ.get("AZURE_OPENAI_KEY", "")
             self.AZURE_SPEECH_KEY = os.environ.get("AZURE_SPEECH_SERVICE_KEY")
         # Set env for OpenAI SDK
-        self.OPENAI_API_BASE = (
-            f"https://{os.getenv('AZURE_OPENAI_RESOURCE')}.openai.azure.com/"
+        self.OPENAI_API_BASE = os.environ.get(
+            "OPENAI_API_BASE", f"https://{self.AZURE_OPENAI_RESOURCE}.openai.azure.com/"
         )
         self.OPENAI_API_TYPE = "azure" if self.AZURE_AUTH_TYPE == "keys" else "azure_ad"
         self.OPENAI_API_KEY = self.AZURE_OPENAI_KEY
         self.OPENAI_API_VERSION = self.AZURE_OPENAI_API_VERSION
         os.environ["OPENAI_API_TYPE"] = self.OPENAI_API_TYPE
-        os.environ["OPENAI_API_BASE"] = (
-            f"https://{os.getenv('AZURE_OPENAI_RESOURCE')}.openai.azure.com/"
-        )
+        os.environ["OPENAI_API_BASE"] = self.OPENAI_API_BASE
         os.environ["OPENAI_API_KEY"] = self.OPENAI_API_KEY
         os.environ["OPENAI_API_VERSION"] = self.OPENAI_API_VERSION
         # Azure Functions - Batch processing

--- a/code/dev-requirements.txt
+++ b/code/dev-requirements.txt
@@ -3,3 +3,4 @@ pytest-cov==4.1.0
 flake8==7.0.0
 pre-commit==3.6.2
 black==24.2.0
+pytest_httpserver==1.0.10

--- a/code/tests/functional/backend_api/app_config.py
+++ b/code/tests/functional/backend_api/app_config.py
@@ -23,10 +23,13 @@ class AppConfig:
     def apply_to_environment(self) -> None:
         for key, value in self.config.items():
             if value is not None:
+                print(f"Applying env var: {key}={value}")
                 os.environ[key] = value
             else:
+                print(f"Removing env var: {key}")
                 os.environ.pop(key, None)
 
     def remove_from_environment(self) -> None:
         for key in self.config.keys():
+            print(f"Removing env var: {key}")
             os.environ.pop(key, None)

--- a/code/tests/functional/backend_api/test_config.py
+++ b/code/tests/functional/backend_api/test_config.py
@@ -16,5 +16,6 @@ def test_config_returned(app_url: str, app_config: AppConfig):
     assert json.loads(response.text) == {
         "azureSpeechKey": app_config.get("AZURE_SPEECH_SERVICE_KEY"),
         "azureSpeechRegion": app_config.get("AZURE_SPEECH_SERVICE_REGION"),
+        "OPENAI_API_BASE": app_config.get("OPENAI_API_BASE"),
     }
     assert response.headers["Content-Type"] == "application/json"

--- a/code/tests/test_app.py
+++ b/code/tests/test_app.py
@@ -11,7 +11,11 @@ class TestConfig:
         response = app.test_client().get("/api/config")
 
         assert response.status_code == 200
-        assert response.json == {"azureSpeechKey": None, "azureSpeechRegion": None}
+        assert response.json == {
+            "azureSpeechKey": None,
+            "azureSpeechRegion": None,
+            "OPENAI_API_BASE": "https://.openai.azure.com/",
+        }
 
 
 class TestConversationCustom:

--- a/code/tests/utilities/test_EnvHelper.py
+++ b/code/tests/utilities/test_EnvHelper.py
@@ -1,0 +1,29 @@
+from pytest import MonkeyPatch
+from backend.batch.utilities.helpers.EnvHelper import EnvHelper
+
+
+def test_openai_base_url_generates_url_based_on_resource_name_if_not_set(
+    monkeypatch: MonkeyPatch,
+):
+    # given
+    openai_resource_name = "some-openai-resource"
+    monkeypatch.delenv("OPENAI_API_BASE")
+    monkeypatch.setenv("AZURE_OPENAI_RESOURCE", openai_resource_name)
+
+    # when
+    actual_open_api_base = EnvHelper().OPENAI_API_BASE
+
+    # then
+    assert actual_open_api_base == f"https://{openai_resource_name}.openai.azure.com/"
+
+
+def test_openai_base_url_uses_env_var_if_set(monkeypatch: MonkeyPatch):
+    # given
+    expected_openai_api_base = "some-openai-resource-base"
+    monkeypatch.setenv("OPENAI_API_BASE", expected_openai_api_base)
+
+    # when
+    actual_open_api_base = EnvHelper().OPENAI_API_BASE
+
+    # then
+    assert actual_open_api_base == expected_openai_api_base


### PR DESCRIPTION
- Based on the ADR https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/blob/main/docs/design/adrs/2024-03-15-use-pytest-httpserver-as-a-mock-server-for-functional-testing.md
- Added `OPENAI_API_BASE` to config endpoint for ease of testing
- Allowed `OPENAI_API_BASE` to be set via an env var
  - Previously this was only generated based on resource name but we
  need more control to set the mock server url
- Add unit tests to `EnvHelper` for this new functionality

Requried by https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/issues/420
