### PR TITLE
Disable report-only-changed-files for forks

### DIFF
--- a/.github/workflows/comment_coverage.yml
+++ b/.github/workflows/comment_coverage.yml
@@ -41,4 +41,4 @@ jobs:
           junitxml-path: coverage-junit.xml
           issue-number: ${{ steps.pr.outputs.result }}
           coverage-path-prefix: code/
-          report-only-changed-files: true
+          report-only-changed-files: ${{ !github.event.workflow_run.head_repository.fork }} # This does not currently work for forks


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Due to a bug in the action, `report-only-changed-files` does not work for PRs from forks, therefore disable this for now until fixed. Note that the action still works and posts successfully, however the workflow exits with an error.

![image](https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/assets/60179183/94152026-f891-432d-9c9f-087fd923b53d)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Tested in fork