### PR TITLE
Change logic to find associated pull request

### DIFF
--- a/.github/workflows/comment_coverage.yml
+++ b/.github/workflows/comment_coverage.yml
@@ -26,18 +26,22 @@ jobs:
       - name: Find associated pull request
         id: pr
         uses: actions/github-script@v7
+        if: ${{ github.event.workflow_run.pull_requests[0].number == null }}
         with:
           script: |
-            const response = await github.rest.search.issuesAndPullRequests({
-              q: "repo:${{ github.repository }} is:pr is:open head:${{ github.event.workflow_run.head_branch }}",
-              per_page: 1,
-            })
+            const response = await github.rest.pulls.list({
+              owner: "${{ github.repository_owner }}",
+              repo: "${{ github.event.workflow_run.repository.name }}",
+              state: "open",
+              head: "${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}",
+            });
 
-            return response.data.items[0]?.number ?? "";
+            return response.data[0]?.number ?? "";
+          retries: 3
       - name: Comment coverage
         uses: MishaKav/pytest-coverage-comment@a1fe18e2b00c64a765568e2edb9f1706eb8fc88b
         with:
           pytest-xml-coverage-path: coverage.xml
           junitxml-path: coverage-junit.xml
-          issue-number: ${{ steps.pr.outputs.result }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number || steps.pr.outputs.result }}
           report-only-changed-files: ${{ !github.event.workflow_run.head_repository.fork }} # This does not currently work for forks


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* We have hit secondary rate limits from the `issuesAndPullRequests()` endpoint, therefore change to use the `pulls.list()` endpoint instead.
* Add retries to the API call
* Only use the GitHub API to get the pull request number if it isn't already available on the `github` object

![image](https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/assets/60179183/e06d8798-540e-4a27-9f97-67c28a665acf)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: CI
```

## How to Test
*  Difficult to test as it only runs on main. I have tested in my own fork. I will review that it is working after merging.