### PR TITLE
Rolled back to previous functions tool

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,11 +5,11 @@
 		"ghcr.io/devcontainers/features/azure-cli:1": {},
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
 		"ghcr.io/devcontainers/features/node:1": {},
-		"ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {},
+		"ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {
+			"version": "4.0.5530"
+		},
 		"ghcr.io/azure/azure-dev/azd:latest": {},
-		"rchaganti/vsc-devcontainer-features/azurebicep": {
-			"version": "latest"
-		}
+		"ghcr.io/rchaganti/vsc-devcontainer-features/azurebicep:1.0.5": {}
 	},
 
 	"postCreateCommand": "./.devcontainer/postCreate.sh",


### PR DESCRIPTION
## Purpose
It appears that there is a problem with the latest version of the Azure Functions Core Tools: https://github.com/Azure/azure-functions-core-tools/releases

For the moment, I have rolled back to 4.0.5530

Hopefully fixes #480

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## How to Test
*  Does the devcontainer build

