### PR TITLE
Verify the downstream calls being made by /conversations/custom

### DIFF
--- a/code/tests/functional/backend_api/app_config.py
+++ b/code/tests/functional/backend_api/app_config.py
@@ -10,9 +10,11 @@ class AppConfig:
         "APPINSIGHTS_ENABLED": "False",
         "AZURE_OPENAI_API_KEY": "some-azure-openai-api-key",
         "AZURE_SEARCH_KEY": "some-azure-search-key",
+        "AZURE_CONTENT_SAFETY_KEY": "some-content_safety-key",
         "AZURE_OPENAI_EMBEDDING_MODEL": "some-embedding-model",
         "AZURE_OPENAI_MODEL": "some-openai-model",
-        "LOAD_CONFIG_FROM_BLOB_STORAGE": "false",
+        "AZURE_SEARCH_CONVERSATIONS_LOG_INDEX": "some-log-index",
+        "LOAD_CONFIG_FROM_BLOB_STORAGE": "False",
         "TIKTOKEN_CACHE_DIR": f"{os.path.dirname(os.path.realpath(__file__))}/resources",
     }
 

--- a/code/tests/functional/backend_api/conftest.py
+++ b/code/tests/functional/backend_api/conftest.py
@@ -73,7 +73,6 @@ def manage_app(app_port: int, app_config: AppConfig):
 def setup_default_mocking(httpserver: HTTPServer, app_config: AppConfig):
     httpserver.expect_request(
         f"/openai/deployments/{app_config.get('AZURE_OPENAI_EMBEDDING_MODEL')}/embeddings",
-        query_string="api-version=2023-12-01-preview",
         method="POST",
     ).respond_with_json(
         {
@@ -90,14 +89,12 @@ def setup_default_mocking(httpserver: HTTPServer, app_config: AppConfig):
     )
 
     httpserver.expect_request(
-        "/indexes('conversations')",
-        query_string="api-version=2023-11-01",
+        f"/indexes('{app_config.get('AZURE_SEARCH_CONVERSATIONS_LOG_INDEX')}')",
         method="GET",
     ).respond_with_json({})
 
     httpserver.expect_request(
         "/contentsafety/text:analyze",
-        query_string="api-version=2023-10-01",
         method="POST",
     ).respond_with_json(
         {
@@ -108,7 +105,6 @@ def setup_default_mocking(httpserver: HTTPServer, app_config: AppConfig):
 
     httpserver.expect_request(
         f"/openai/deployments/{app_config.get('AZURE_OPENAI_MODEL')}/chat/completions",
-        query_string="api-version=2023-12-01-preview",
         method="POST",
     ).respond_with_json(
         {
@@ -135,8 +131,7 @@ def setup_default_mocking(httpserver: HTTPServer, app_config: AppConfig):
     )
 
     httpserver.expect_request(
-        "/indexes('conversations')/docs/search.index",
-        query_string="api-version=2023-11-01",
+        f"/indexes('{app_config.get('AZURE_SEARCH_CONVERSATIONS_LOG_INDEX')}')/docs/search.index",
         method="POST",
     ).respond_with_json(
         {

--- a/code/tests/functional/backend_api/conftest.py
+++ b/code/tests/functional/backend_api/conftest.py
@@ -16,11 +16,19 @@ import app
 
 @pytest.fixture(scope="session")
 def ca():
+    """
+    This fixture is required to run the http mock server with SSL.
+    https://pytest-httpserver.readthedocs.io/en/latest/howto.html#running-an-https-server
+    """
     return trustme.CA()
 
 
 @pytest.fixture(scope="session")
 def httpserver_ssl_context(ca):
+    """
+    This fixture is required to run the http mock server with SSL.
+    https://pytest-httpserver.readthedocs.io/en/latest/howto.html#running-an-https-server
+    """
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     localhost_cert = ca.issue_cert("localhost")
     localhost_cert.configure_cert(context)
@@ -29,6 +37,10 @@ def httpserver_ssl_context(ca):
 
 @pytest.fixture(scope="session")
 def httpclient_ssl_context(ca):
+    """
+    This fixture is required to run the http mock server with SSL.
+    https://pytest-httpserver.readthedocs.io/en/latest/howto.html#running-an-https-server
+    """
     with ca.cert_pem.tempfile() as ca_temp_path:
         return ssl.create_default_context(cafile=ca_temp_path)
 

--- a/code/tests/functional/backend_api/request_matching.py
+++ b/code/tests/functional/backend_api/request_matching.py
@@ -1,4 +1,3 @@
-import logging
 from pytest_httpserver import HTTPServer
 from werkzeug.wrappers import Request
 
@@ -64,18 +63,14 @@ def verify_request_made(mock_httpserver: HTTPServer, request_matcher: RequestMat
 
             matching_requests.append(request)
 
+    error_message = f"Matching request found {len(matching_requests)} times but expected {request_matcher.times} times. \n Expected request: {request_matcher}\n Found similar requests:"
     if len(matching_requests) != request_matcher.times:
-        string_requests = ""
         for request in similar_requests:
-            string_requests += "\n--- Similar Request Start"
-            string_requests += f"\nPath: {request.path}, Method: {request.method}, Body: {request.get_data()}, Headers: {request.headers} Query String: {request.query_string.decode('utf-8')}"
-            string_requests += "\n--- Similar Request End"
+            error_message += "\n--- Similar Request Start"
+            error_message += f"\nPath: {request.path}, Method: {request.method}, Body: {request.get_data()}, Headers: {request.headers} Query String: {request.query_string.decode('utf-8')}"
+            error_message += "\n--- Similar Request End"
 
-        logging.info(
-            f"Matching request found {len(matching_requests)} times but expected {request_matcher.times} times. \n Expected request: {request_matcher}\n Found similar requests: {string_requests}"
-        )
-
-    assert len(matching_requests) == request_matcher.times
+    assert len(matching_requests) == request_matcher.times, error_message
 
 
 def contains_all_headers(request_matcher: RequestMatcher, request: Request):

--- a/code/tests/functional/backend_api/request_matching.py
+++ b/code/tests/functional/backend_api/request_matching.py
@@ -1,0 +1,86 @@
+import logging
+from pytest_httpserver import HTTPServer
+from werkzeug.wrappers import Request
+
+
+class RequestMatcher:
+    path: str
+    method: str
+    json: dict
+    headers: dict
+    query_string: dict
+    times: int
+
+    def __init__(
+        self,
+        path: str,
+        method: str,
+        json: dict = None,
+        headers: dict = None,
+        query_string: str = None,
+        times: int = 1,
+    ):
+        self.path = path
+        self.method = method
+        self.json = json
+        self.headers = headers
+        self.query_string = query_string
+        self.times = times
+
+    def __str__(self):
+        return f"Path: {self.path}, Method: {self.method}, JSON: {self.json}, Headers: {self.headers}, Query String: {self.query_string}, Times: {self.times}"
+
+
+def verify_request_made(mock_httpserver: HTTPServer, request_matcher: RequestMatcher):
+    requests_log = mock_httpserver.log
+
+    similar_requests = []
+    matching_requests = []
+    for request_log in requests_log:
+        request = request_log[0]
+
+        if request.path == request_matcher.path:
+            similar_requests.append(request)
+
+            if request.method != request_matcher.method:
+                continue
+
+            if (
+                request_matcher.json is not None
+                and request.json != request_matcher.json
+            ):
+                continue
+
+            if request_matcher.headers is not None and not contains_all_headers(
+                request_matcher, request
+            ):
+                continue
+
+            if (
+                request_matcher.query_string is not None
+                and request.query_string.decode("utf-8") != request_matcher.query_string
+            ):
+                continue
+
+            matching_requests.append(request)
+
+    if len(matching_requests) != request_matcher.times:
+        string_requests = ""
+        for request in similar_requests:
+            string_requests += "\n--- Similar Request Start"
+            string_requests += f"\nPath: {request.path}, Method: {request.method}, Body: {request.get_data()}, Headers: {request.headers} Query String: {request.query_string.decode('utf-8')}"
+            string_requests += "\n--- Similar Request End"
+
+        logging.info(
+            f"Matching request found {len(matching_requests)} times but expected {request_matcher.times} times. \n Expected request: {request_matcher}\n Found similar requests: {string_requests}"
+        )
+
+    assert len(matching_requests) == request_matcher.times
+
+
+def contains_all_headers(request_matcher: RequestMatcher, request: Request):
+    for key, value in request_matcher.headers.items():
+        if request.headers.get(key) != value:
+            return False
+
+    return True

--- a/code/tests/functional/backend_api/test_conversation_custom.py
+++ b/code/tests/functional/backend_api/test_conversation_custom.py
@@ -58,6 +58,8 @@ def test_post_makes_correct_call_to_openai_embeddings(
 ):
     # when
     requests.post(f"{app_url}{path}", json=body)
+
+    # then
     verify_request_made(
         mock_httpserver=httpserver,
         request_matcher=RequestMatcher(
@@ -85,6 +87,8 @@ def test_post_makes_correct_call_to_get_search_index(
 ):
     # when
     requests.post(f"{app_url}{path}", json=body)
+
+    # then
     verify_request_made(
         mock_httpserver=httpserver,
         request_matcher=RequestMatcher(
@@ -105,6 +109,8 @@ def test_post_makes_correct_call_to_content_safety_analyze(
 ):
     # when
     requests.post(f"{app_url}{path}", json=body)
+
+    # then
     verify_request_made(
         mock_httpserver=httpserver,
         request_matcher=RequestMatcher(
@@ -127,6 +133,8 @@ def test_post_makes_correct_call_to_openai_chat_completions(
 ):
     # when
     requests.post(f"{app_url}{path}", json=body)
+
+    # then
     verify_request_made(
         mock_httpserver=httpserver,
         request_matcher=RequestMatcher(
@@ -196,6 +204,8 @@ def test_post_makes_correct_call_to_store_conversation_in_search(
 ):
     # when
     requests.post(f"{app_url}{path}", json=body)
+
+    # then
     verify_request_made(
         mock_httpserver=httpserver,
         request_matcher=RequestMatcher(

--- a/code/tests/functional/backend_api/test_conversation_custom.py
+++ b/code/tests/functional/backend_api/test_conversation_custom.py
@@ -1,25 +1,30 @@
 import json
 import pytest
+from pytest_httpserver import HTTPServer
 import requests
 
+from tests.functional.backend_api.request_matching import (
+    RequestMatcher,
+    verify_request_made,
+)
 from tests.functional.backend_api.app_config import AppConfig
 
 pytestmark = pytest.mark.functional
 
+path = "/api/conversation/custom"
+body = {
+    "conversation_id": "123",
+    "messages": [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi, how can I help?"},
+        {"role": "user", "content": "What is the meaning of life?"},
+    ],
+}
 
-def test_post(app_url: str, app_config: AppConfig):
+
+def test_post_responds_successfully(app_url: str, app_config: AppConfig):
     # when
-    response = requests.post(
-        f"{app_url}/api/conversation/custom",
-        json={
-            "conversation_id": "123",
-            "messages": [
-                {"role": "user", "content": "Hello"},
-                {"role": "assistant", "content": "Hi, how can I help?"},
-                {"role": "user", "content": "What is the meaning of life?"},
-            ],
-        },
-    )
+    response = requests.post(f"{app_url}{path}", json=body)
 
     # then
     assert response.status_code == 200
@@ -46,3 +51,162 @@ def test_post(app_url: str, app_config: AppConfig):
         "object": "response.object",
     }
     assert response.headers["Content-Type"] == "application/json"
+
+
+def test_post_makes_correct_call_to_openai_embeddings(
+    app_url: str, app_config: AppConfig, httpserver: HTTPServer
+):
+    # when
+    requests.post(f"{app_url}{path}", json=body)
+    verify_request_made(
+        mock_httpserver=httpserver,
+        request_matcher=RequestMatcher(
+            path=f"/openai/deployments/{app_config.get('AZURE_OPENAI_EMBEDDING_MODEL')}/embeddings",
+            method="POST",
+            json={
+                "input": [[1199]],
+                "model": "text-embedding-ada-002",
+                "encoding_format": "base64",
+            },
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {app_config.get('AZURE_OPENAI_API_KEY')}",
+                "Api-Key": app_config.get("AZURE_OPENAI_API_KEY"),
+            },
+            query_string="api-version=2023-12-01-preview",
+            times=2,
+        ),
+    )
+
+
+def test_post_makes_correct_call_to_get_search_index(
+    app_url: str, app_config: AppConfig, httpserver: HTTPServer
+):
+    # when
+    requests.post(f"{app_url}{path}", json=body)
+    verify_request_made(
+        mock_httpserver=httpserver,
+        request_matcher=RequestMatcher(
+            path=f"/indexes('{app_config.get('AZURE_SEARCH_CONVERSATIONS_LOG_INDEX')}')",
+            method="GET",
+            headers={
+                "Accept": "application/json;odata.metadata=minimal",
+                "Api-Key": app_config.get("AZURE_SEARCH_KEY"),
+            },
+            query_string="api-version=2023-11-01",
+            times=1,
+        ),
+    )
+
+
+def test_post_makes_correct_call_to_content_safety_analyze(
+    app_url: str, app_config: AppConfig, httpserver: HTTPServer
+):
+    # when
+    requests.post(f"{app_url}{path}", json=body)
+    verify_request_made(
+        mock_httpserver=httpserver,
+        request_matcher=RequestMatcher(
+            path="/contentsafety/text:analyze",
+            method="POST",
+            json={"text": "42 is the meaning of life"},
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "Ocp-Apim-Subscription-Key": app_config.get("AZURE_CONTENT_SAFETY_KEY"),
+            },
+            query_string="api-version=2023-10-01",
+            times=1,
+        ),
+    )
+
+
+def test_post_makes_correct_call_to_openai_chat_completions(
+    app_url: str, app_config: AppConfig, httpserver: HTTPServer
+):
+    # when
+    requests.post(f"{app_url}{path}", json=body)
+    verify_request_made(
+        mock_httpserver=httpserver,
+        request_matcher=RequestMatcher(
+            path=f"/openai/deployments/{app_config.get('AZURE_OPENAI_MODEL')}/chat/completions",
+            method="POST",
+            json={
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You help employees to navigate only private information sources.\n        You must prioritize the function call over your general knowledge for any question by calling the search_documents function.\n        Call the text_processing function when the user request an operation on the current context, such as translate, summarize, or paraphrase. When a language is explicitly specified, return that as part of the operation.\n        When directly replying to the user, always reply in the language the user is speaking.\n        ",
+                    },
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi, how can I help?"},
+                    {"role": "user", "content": "What is the meaning of life?"},
+                ],
+                "model": "some-openai-model",
+                "function_call": "auto",
+                "functions": [
+                    {
+                        "name": "search_documents",
+                        "description": "Provide answers to any fact question coming from users.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "question": {
+                                    "type": "string",
+                                    "description": "A standalone question, converted from the chat history",
+                                }
+                            },
+                            "required": ["question"],
+                        },
+                    },
+                    {
+                        "name": "text_processing",
+                        "description": "Useful when you want to apply a transformation on the text, like translate, summarize, rephrase and so on.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "text": {
+                                    "type": "string",
+                                    "description": "The text to be processed",
+                                },
+                                "operation": {
+                                    "type": "string",
+                                    "description": "The operation to be performed on the text. Like Translate to Italian, Summarize, Paraphrase, etc. If a language is specified, return that as part of the operation. Preserve the operation name in the user language.",
+                                },
+                            },
+                            "required": ["text", "operation"],
+                        },
+                    },
+                ],
+            },
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {app_config.get('AZURE_OPENAI_API_KEY')}",
+                "Api-Key": app_config.get("AZURE_OPENAI_API_KEY"),
+            },
+            query_string="api-version=2023-12-01-preview",
+            times=1,
+        ),
+    )
+
+
+def test_post_makes_correct_call_to_store_conversation_in_search(
+    app_url: str, app_config: AppConfig, httpserver: HTTPServer
+):
+    # when
+    requests.post(f"{app_url}{path}", json=body)
+    verify_request_made(
+        mock_httpserver=httpserver,
+        request_matcher=RequestMatcher(
+            path=f"/indexes('{app_config.get('AZURE_SEARCH_CONVERSATIONS_LOG_INDEX')}')/docs/search.index",
+            method="POST",
+            headers={
+                "Accept": "application/json;odata.metadata=none",
+                "Content-Type": "application/json",
+                "Api-Key": app_config.get("AZURE_SEARCH_KEY"),
+            },
+            query_string="api-version=2023-11-01",
+            times=2,
+        ),
+    )


### PR DESCRIPTION
- To ensure we are making the correct calls, with the correct api keys, api version, index information and request bodies
- Implemented using a generic request matcher for now
  - This should be added to the mock server library by https://github.com/csernazs/pytest-httpserver/issues/293
- Added extra tests rather then combining al the verifications in one test
  - This is so that the failure reason should be clearer
  - I was concerned that this would significantly increase the test run time however it made no difference and some runs after were actually quicker then if it was a single test
 
Required by https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/issues/420
