### PR TITLE
Allow langchain agent errors to propogate

### DIFF
--- a/code/backend/batch/utilities/orchestrator/LangChainAgent.py
+++ b/code/backend/batch/utilities/orchestrator/LangChainAgent.py
@@ -25,6 +25,7 @@ class LangChainAgent(OrchestratorBase):
         self.question_answer_tool = QuestionAnswerTool()
         self.text_processing_tool = TextProcessingTool()
         self.output_parser = OutputParserTool()
+        self.llm_helper = LLMHelper()
 
         self.tools = [
             Tool(
@@ -77,7 +78,6 @@ class LangChainAgent(OrchestratorBase):
                 return messages
 
         # Call function to determine route
-        llm_helper = LLMHelper()
         prefix = """Have a conversation with a human, answering the following questions as best you can. You have access to the following tools:"""
         suffix = """Begin!"
 
@@ -100,7 +100,7 @@ class LangChainAgent(OrchestratorBase):
             elif message["role"] == "assistant":
                 memory.chat_memory.add_ai_message(message["content"])
         # Define Agent and Agent Chain
-        llm_chain = LLMChain(llm=llm_helper.get_llm(), prompt=prompt)
+        llm_chain = LLMChain(llm=self.llm_helper.get_llm(), prompt=prompt)
         agent = ZeroShotAgent(llm_chain=llm_chain, tools=self.tools, verbose=True)
         agent_chain = AgentExecutor.from_agent_and_tools(
             agent=agent, tools=self.tools, verbose=True, memory=memory

--- a/code/tests/utilities/test_LangChainAgent.py
+++ b/code/tests/utilities/test_LangChainAgent.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+import pytest
 
 from backend.batch.utilities.orchestrator.LangChainAgent import LangChainAgent
 from backend.batch.utilities.common.Answer import Answer
@@ -9,6 +10,10 @@ class LangChainAgentNoInit(LangChainAgent):
         self.content_safety_checker = MagicMock()
         self.question_answer_tool = MagicMock()
         self.text_processing_tool = MagicMock()
+        self.config = MagicMock()
+        self.output_parser = MagicMock()
+        self.tools = MagicMock()
+        self.tokens = {"prompt": 0, "completion": 0, "total": 0}
 
 
 def test_run_tool_returns_answer_json():
@@ -61,3 +66,48 @@ def test_run_text_processing_tool_returns_answer_json():
     agent.text_processing_tool.answer_question.assert_called_once_with(
         user_message, chat_history=[]
     )
+
+
+@patch("langchain.agents.AgentExecutor.from_agent_and_tools")
+def test_orchestrate_langchain_to_orchestrate_chat(agent_executor_mock):
+    # Given
+    agent = LangChainAgentNoInit()
+
+    agent.config.prompts.enable_post_answering_prompt = False
+    agent.config.prompts.enable_content_safety = False
+
+    agent_chain_mock = MagicMock()
+    agent_executor_mock.return_value = agent_chain_mock
+    agent_chain_mock.run.return_value = '{"question": "Hello", "answer": "Hello, how can I help you?", "source_documents": [], "prompt_tokens": null, "completion_tokens": null}'
+
+    expected_messages = [{"some", "message"}, {"another", "message"}]
+    agent.output_parser.parse.return_value = expected_messages
+
+    # When
+    actual_messages = agent.orchestrate(user_message="Hello", chat_history=[])
+
+    # Then
+    assert actual_messages == expected_messages
+    agent_chain_mock.run.assert_called_once_with("Hello")
+    agent.output_parser.parse.assert_called_once_with(
+        question="Hello", answer="Hello, how can I help you?", source_documents=[]
+    )
+
+
+@patch("langchain.agents.AgentExecutor.from_agent_and_tools")
+def test_orchestrate_returns_error_message_on_Exception(agent_executor_mock):
+    # Given
+    agent = LangChainAgentNoInit()
+
+    agent.config.prompts.enable_post_answering_prompt = False
+    agent.config.prompts.enable_content_safety = False
+
+    agent_chain_mock = MagicMock()
+    agent_executor_mock.return_value = agent_chain_mock
+    agent_chain_mock.run.side_effect = Exception("Some error")
+
+    agent.output_parser.parse.return_value = [{"some", "message"}]
+
+    # When + Then
+    with pytest.raises(Exception):
+        agent.orchestrate(user_message="Hello", chat_history=[])

--- a/code/tests/utilities/test_LangChainAgent.py
+++ b/code/tests/utilities/test_LangChainAgent.py
@@ -13,6 +13,7 @@ class LangChainAgentNoInit(LangChainAgent):
         self.config = MagicMock()
         self.output_parser = MagicMock()
         self.tools = MagicMock()
+        self.llm_helper = MagicMock()
         self.tokens = {"prompt": 0, "completion": 0, "total": 0}
 
 
@@ -68,8 +69,12 @@ def test_run_text_processing_tool_returns_answer_json():
     )
 
 
+@patch("backend.batch.utilities.orchestrator.LangChainAgent.ZeroShotAgent")
+@patch("backend.batch.utilities.orchestrator.LangChainAgent.LLMChain")
 @patch("langchain.agents.AgentExecutor.from_agent_and_tools")
-def test_orchestrate_langchain_to_orchestrate_chat(agent_executor_mock):
+def test_orchestrate_langchain_to_orchestrate_chat(
+    agent_executor_mock, llm_chain_mock, zero_shot_agent_mock
+):
     # Given
     agent = LangChainAgentNoInit()
 
@@ -94,8 +99,12 @@ def test_orchestrate_langchain_to_orchestrate_chat(agent_executor_mock):
     )
 
 
+@patch("backend.batch.utilities.orchestrator.LangChainAgent.ZeroShotAgent")
+@patch("backend.batch.utilities.orchestrator.LangChainAgent.LLMChain")
 @patch("langchain.agents.AgentExecutor.from_agent_and_tools")
-def test_orchestrate_returns_error_message_on_Exception(agent_executor_mock):
+def test_orchestrate_returns_error_message_on_Exception(
+    agent_executor_mock, llm_chain_mock, zero_shot_agent_mock
+):
     # Given
     agent = LangChainAgentNoInit()
 


### PR DESCRIPTION
- This is to address a security issue where stacktraces may get returned
  to the user https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/security/code-scanning/7
- This exception will be caught in the
  `create_app.conversation_custom()` function https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/blob/b291c55eeded213a70508db57b4d9318d53a3115/code/create_app.py#L371
