### PR TITLE
Bump version of nodemon

### DIFF
--- a/extensions/teams/package.json
+++ b/extensions/teams/package.json
@@ -30,7 +30,7 @@
         "@types/node": "^18.20.1",
         "@types/restify": "^8.5.5",
         "env-cmd": "^10.1.0",
-        "nodemon": "^2.0.7",
+        "nodemon": "^3.1.0",
         "shx": "^0.3.3",
         "ts-node": "^10.4.0",
         "typescript": "^4.4.4"


### PR DESCRIPTION
- This is to fix a security issue around it's transitive dependency, semver https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/security/dependabot/36
- This older version of nodemon is currently pinning semver to an older version with security vulnerbilities
- This was recently downgraded by https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/pull/599 to align with the teams toolkit recommendations, however this is not a critical dependency and is only used to monitor code changes during local development
