### PR TITLE
Correctly bump node versions

### DIFF
--- a/extensions/teams/package-lock.json
+++ b/extensions/teams/package-lock.json
@@ -13,10 +13,10 @@
                 "restify": "^10.0.0"
             },
             "devDependencies": {
-                "@types/node": "^18.20.1",
+                "@types/node": "^18.19.31",
                 "@types/restify": "^8.5.5",
                 "env-cmd": "^10.1.0",
-                "nodemon": "^2.0.7",
+                "nodemon": "^3.1.0",
                 "shx": "^0.3.3",
                 "ts-node": "^10.4.0",
                 "typescript": "^4.4.4"
@@ -1971,18 +1971,18 @@
             }
         },
         "node_modules/nodemon": {
-            "version": "2.0.22",
-            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
-            "integrity": "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.0.tgz",
+            "integrity": "sha512-xqlktYlDMCepBJd43ZQhjWwMw2obW/JRvkrLxq5RCNcuDDX1DbcPT+qT1IlIIdf+DhnWs90JpTMe+Y5KxOchvA==",
             "dev": true,
             "dependencies": {
                 "chokidar": "^3.5.2",
-                "debug": "^3.2.7",
+                "debug": "^4",
                 "ignore-by-default": "^1.0.1",
                 "minimatch": "^3.1.2",
                 "pstree.remy": "^1.1.8",
-                "semver": "^5.7.1",
-                "simple-update-notifier": "^1.0.7",
+                "semver": "^7.5.3",
+                "simple-update-notifier": "^2.0.0",
                 "supports-color": "^5.5.0",
                 "touch": "^3.1.0",
                 "undefsafe": "^2.0.5"
@@ -1991,29 +1991,11 @@
                 "nodemon": "bin/nodemon.js"
             },
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">=10"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/nodemon"
-            }
-        },
-        "node_modules/nodemon/node_modules/debug": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "^2.1.1"
-            }
-        },
-        "node_modules/nodemon/node_modules/semver": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver"
             }
         },
         "node_modules/nopt": {
@@ -2604,24 +2586,15 @@
             }
         },
         "node_modules/simple-update-notifier": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
-            "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+            "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
             "dev": true,
             "dependencies": {
-                "semver": "~7.0.0"
+                "semver": "^7.5.3"
             },
             "engines": {
-                "node": ">=8.10.0"
-            }
-        },
-        "node_modules/simple-update-notifier/node_modules/semver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-            "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
+                "node": ">=10"
             }
         },
         "node_modules/sonic-boom": {
@@ -4579,38 +4552,21 @@
             }
         },
         "nodemon": {
-            "version": "2.0.22",
-            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
-            "integrity": "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.0.tgz",
+            "integrity": "sha512-xqlktYlDMCepBJd43ZQhjWwMw2obW/JRvkrLxq5RCNcuDDX1DbcPT+qT1IlIIdf+DhnWs90JpTMe+Y5KxOchvA==",
             "dev": true,
             "requires": {
                 "chokidar": "^3.5.2",
-                "debug": "^3.2.7",
+                "debug": "^4",
                 "ignore-by-default": "^1.0.1",
                 "minimatch": "^3.1.2",
                 "pstree.remy": "^1.1.8",
-                "semver": "^5.7.1",
-                "simple-update-notifier": "^1.0.7",
+                "semver": "^7.5.3",
+                "simple-update-notifier": "^2.0.0",
                 "supports-color": "^5.5.0",
                 "touch": "^3.1.0",
                 "undefsafe": "^2.0.5"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.2.7",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "semver": {
-                    "version": "5.7.2",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-                    "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-                    "dev": true
-                }
             }
         },
         "nopt": {
@@ -5055,20 +5011,12 @@
             }
         },
         "simple-update-notifier": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
-            "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+            "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
             "dev": true,
             "requires": {
-                "semver": "~7.0.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-                    "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-                    "dev": true
-                }
+                "semver": "^7.5.3"
             }
         },
         "sonic-boom": {

--- a/extensions/teams/package.json
+++ b/extensions/teams/package.json
@@ -27,7 +27,7 @@
         "restify": "^10.0.0"
     },
     "devDependencies": {
-        "@types/node": "^18.20.1",
+        "@types/node": "^18.19.31",
         "@types/restify": "^8.5.5",
         "env-cmd": "^10.1.0",
         "nodemon": "^3.1.0",


### PR DESCRIPTION
- The previous PR (https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/pull/678) did not update the `package-lock.json` so the issue is not resolved.
- This was due to the `@types.node` version being invalid. I've changed it to the latest `18.*` version as listed here https://www.npmjs.com/package/@types/node?activeTab=versions
