### PR TITLE
Make EnvHelper a singleton

### DIFF
--- a/code/backend/batch/utilities/helpers/EnvHelper.py
+++ b/code/backend/batch/utilities/helpers/EnvHelper.py
@@ -8,8 +8,18 @@ logger = logging.getLogger(__name__)
 
 
 class EnvHelper:
-    def __init__(self, **kwargs) -> None:
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(EnvHelper, cls).__new__(cls)
+            cls._instance.__load_config()
+        return cls._instance
+
+    def __load_config(self, **kwargs) -> None:
         load_dotenv()
+
+        logger.info("Initializing EnvHelper")
 
         # Wrapper for Azure Key Vault
         self.secretHelper = SecretHelper()
@@ -187,6 +197,11 @@ class EnvHelper:
         for attr, value in EnvHelper().__dict__.items():
             if value == "":
                 logger.warning(f"{attr} is not set in the environment variables.")
+
+    @classmethod
+    def clear_instance(cls):
+        if cls._instance is not None:
+            cls._instance = None
 
 
 class SecretHelper:

--- a/code/tests/functional/backend_api/common.py
+++ b/code/tests/functional/backend_api/common.py
@@ -5,12 +5,14 @@ import time
 import requests
 from threading import Thread
 from create_app import create_app
+from backend.batch.utilities.helpers.EnvHelper import EnvHelper
 
 logger = logging.getLogger(__name__)
 
 
 def start_app(app_port: int) -> Thread:
     logger.info(f"Starting application on port {app_port}")
+    EnvHelper.clear_instance()
     app = create_app()
     app_process = threading.Thread(target=lambda: app.run(port=app_port), daemon=True)
     app_process.start()

--- a/code/tests/functional/backend_api/common.py
+++ b/code/tests/functional/backend_api/common.py
@@ -5,14 +5,12 @@ import time
 import requests
 from threading import Thread
 from create_app import create_app
-from backend.batch.utilities.helpers.EnvHelper import EnvHelper
 
 logger = logging.getLogger(__name__)
 
 
 def start_app(app_port: int) -> Thread:
     logger.info(f"Starting application on port {app_port}")
-    EnvHelper.clear_instance()
     app = create_app()
     app_process = threading.Thread(target=lambda: app.run(port=app_port), daemon=True)
     app_process.start()

--- a/code/tests/functional/backend_api/tests/with_data/conftest.py
+++ b/code/tests/functional/backend_api/tests/with_data/conftest.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 from tests.functional.backend_api.app_config import AppConfig
 from tests.functional.backend_api.common import get_free_port, start_app
+from backend.batch.utilities.helpers.EnvHelper import EnvHelper
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,8 @@ def app_config(make_httpserver, ca):
 @pytest.fixture(scope="package", autouse=True)
 def manage_app(app_port: int, app_config: AppConfig):
     app_config.apply_to_environment()
+    EnvHelper.clear_instance()
     start_app(app_port)
     yield
     app_config.remove_from_environment()
+    EnvHelper.clear_instance()

--- a/code/tests/functional/backend_api/tests/without_data/conftest.py
+++ b/code/tests/functional/backend_api/tests/without_data/conftest.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 from tests.functional.backend_api.app_config import AppConfig
 from tests.functional.backend_api.common import get_free_port, start_app
+from backend.batch.utilities.helpers.EnvHelper import EnvHelper
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,8 @@ def app_config(make_httpserver, ca):
 @pytest.fixture(scope="package", autouse=True)
 def manage_app(app_port: int, app_config: AppConfig):
     app_config.apply_to_environment()
+    EnvHelper.clear_instance()
     start_app(app_port)
     yield
     app_config.remove_from_environment()
+    EnvHelper.clear_instance()

--- a/code/tests/utilities/test_EnvHelper.py
+++ b/code/tests/utilities/test_EnvHelper.py
@@ -3,6 +3,12 @@ import pytest
 from backend.batch.utilities.helpers.EnvHelper import EnvHelper
 
 
+@pytest.fixture(autouse=True)
+def cleanup():
+    yield
+    EnvHelper.clear_instance()
+
+
 def test_openai_base_url_generates_url_based_on_resource_name_if_not_set(
     monkeypatch: MonkeyPatch,
 ):

--- a/code/tests/utilities/test_EnvHelper.py
+++ b/code/tests/utilities/test_EnvHelper.py
@@ -5,6 +5,7 @@ from backend.batch.utilities.helpers.EnvHelper import EnvHelper
 
 @pytest.fixture(autouse=True)
 def cleanup():
+    EnvHelper.clear_instance()
     yield
     EnvHelper.clear_instance()
 

--- a/code/tests/utilities/test_EnvHelper.py
+++ b/code/tests/utilities/test_EnvHelper.py
@@ -10,6 +10,10 @@ def cleanup():
     EnvHelper.clear_instance()
 
 
+def test_env_helper_is_singleton():
+    assert EnvHelper() is EnvHelper()
+
+
 def test_openai_base_url_generates_url_based_on_resource_name_if_not_set(
     monkeypatch: MonkeyPatch,
 ):


### PR DESCRIPTION
- The current setup means we create 23 instances of this when submitting a question via the UI
- A timed single question via the UI took 62 seconds to get an answer
- After this change, the same question took 8 seconds to get an answer
- Obviously this isn't very robust testing! But the improvement is obvious
- Decided to pick this up as it's having an affect on code design reviews

Required by https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/issues/508
