### PR TITLE
Resolve muiltithreading issues around EnvHelper singleton

### DIFF
--- a/code/backend/batch/utilities/helpers/EnvHelper.py
+++ b/code/backend/batch/utilities/helpers/EnvHelper.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import threading
 from dotenv import load_dotenv
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from azure.keyvault.secrets import SecretClient
@@ -9,12 +10,14 @@ logger = logging.getLogger(__name__)
 
 class EnvHelper:
     _instance = None
+    _lock = threading.Lock()
 
     def __new__(cls):
-        if cls._instance is None:
-            cls._instance = super(EnvHelper, cls).__new__(cls)
-            cls._instance.__load_config()
-        return cls._instance
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super(EnvHelper, cls).__new__(cls)
+                cls._instance.__load_config()
+            return cls._instance
 
     def __load_config(self, **kwargs) -> None:
         load_dotenv()


### PR DESCRIPTION
- We're occasionally seeing the below error when ingesting:
```
Exception while executing function: Functions.batch_push_results Result: Failure
Exception: AttributeError: 'EnvHelper' object has no attribute 'AZURE_BLOB_ACCOUNT_NAME'
Stack:   File "/azure-functions-host/workers/python/3.11/LINUX/X64/azure_functions_worker/dispatcher.py", line 505, in _handle__invocation_request
    call_result = await self._loop.run_in_executor(
has context menu
```
- I believe this is caused by multiple threads running at the same time
  - The first one creates the instance and starts populating the config
  - The second sees the instance the first one has created, but tries to use it before the config has been populated
- This change wraps the code in a lock to ensure only one thread at a time can get an instance of the EnvHelper
