### PR TITLE
Fetch coverage only for PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Get coverage artifact ID
         id: coverage-artifact
         uses: actions/github-script@v7
+        if: github.event_name == 'pull_request'
         with:
           script: |
             const workflows = await github.rest.actions.listRepoWorkflows({
@@ -59,7 +60,7 @@ jobs:
           retries: 3
       - name: Download main coverage artifact
         uses: actions/download-artifact@v4
-        if: steps.coverage-artifact.outputs.result != ''
+        if: github.event_name == 'pull_request' && steps.coverage-artifact.outputs.result != ''
         continue-on-error: true # There is a chance that the artifact doesn't exist, or has expired
         with:
           name: coverage


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Only attempt to download the coverage when running on a PR

There have been some errors when attempting to run the workflow on branches, rather than pull requests, as `github.base_ref` is only available when running on a PR.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: CI
```

## How to Test
* Check workflow run for this PR