### PR TITLE
Fix issue with env vars clashing with functional tests

### DIFF
--- a/code/backend/batch/utilities/helpers/EnvHelper.py
+++ b/code/backend/batch/utilities/helpers/EnvHelper.py
@@ -46,7 +46,7 @@ class EnvHelper:
             "AZURE_SEARCH_INDEX_IS_PRECHUNKED", ""
         )
         self.AZURE_SEARCH_FILTER = os.getenv("AZURE_SEARCH_FILTER", "")
-        self.AZURE_SEARCH_TOP_K = os.getenv("AZURE_SEARCH_TOP_K", 5)
+        self.AZURE_SEARCH_TOP_K = int(os.getenv("AZURE_SEARCH_TOP_K", "5"))
         self.AZURE_SEARCH_ENABLE_IN_DOMAIN = (
             os.getenv("AZURE_SEARCH_ENABLE_IN_DOMAIN", "true").lower() == "true"
         )

--- a/code/tests/functional/backend_api/app_config.py
+++ b/code/tests/functional/backend_api/app_config.py
@@ -5,7 +5,7 @@ logger = logging.getLogger(__name__)
 
 
 class AppConfig:
-    before_config: dict[str, str | None] = {}
+    before_config: dict[str, str] = {}
     config: dict[str, str | None] = {
         "APPINSIGHTS_CONNECTION_STRING": "",
         "APPINSIGHTS_ENABLED": "False",

--- a/code/tests/functional/backend_api/app_config.py
+++ b/code/tests/functional/backend_api/app_config.py
@@ -5,23 +5,67 @@ logger = logging.getLogger(__name__)
 
 
 class AppConfig:
+    before_config: dict[str, str | None] = {}
     config: dict[str, str | None] = {
-        "AZURE_SPEECH_SERVICE_KEY": "some-azure-speech-service-key",
-        "AZURE_SPEECH_SERVICE_REGION": "some-azure-speech-service-region",
-        "SPEECH_RECOGNIZER_LANGUAGES": "en-US,es-ES",
+        "APPINSIGHTS_CONNECTION_STRING": "",
         "APPINSIGHTS_ENABLED": "False",
+        "AZURE_AUTH_TYPE": "keys",
+        "AZURE_BLOB_ACCOUNT_KEY": "some-blob-account-key",
+        "AZURE_BLOB_ACCOUNT_NAME": "some-blob-account-name",
+        "AZURE_BLOB_CONTAINER_NAME": "some-blob-container-name",
+        "AZURE_CONTENT_SAFETY_ENDPOINT": "some-content-safety-endpoint",
+        "AZURE_CONTENT_SAFETY_KEY": "some-content-safety-key",
+        "AZURE_FORM_RECOGNIZER_ENDPOINT": "some-form-recognizer-endpoint",
+        "AZURE_FORM_RECOGNIZER_KEY": "some-form-recognizer-key",
+        "AZURE_KEY_VAULT_ENDPOINT": "some-key-vault-endpoint",
         "AZURE_OPENAI_API_KEY": "some-azure-openai-api-key",
         "AZURE_OPENAI_API_VERSION": "2024-02-01",
-        "AZURE_SEARCH_INDEX": "some-azure-search-index",
-        "AZURE_SEARCH_KEY": "some-azure-search-key",
-        "AZURE_SEARCH_FILTER": "some-search-filter",
-        "AZURE_CONTENT_SAFETY_KEY": "some-content_safety-key",
         "AZURE_OPENAI_EMBEDDING_MODEL": "some-embedding-model",
+        "AZURE_OPENAI_ENDPOINT": "some-openai-endpoint",
+        "AZURE_OPENAI_MAX_TOKENS": "1000",
         "AZURE_OPENAI_MODEL": "some-openai-model",
-        "AZURE_SEARCH_CONVERSATIONS_LOG_INDEX": "some-log-index",
+        "AZURE_OPENAI_MODEL_NAME": "some-openai-model-name",
+        "AZURE_OPENAI_RESOURCE": "some-openai-resource",
         "AZURE_OPENAI_STREAM": "True",
+        "AZURE_OPENAI_STOP_SEQUENCE": "",
+        "AZURE_OPENAI_SYSTEM_MESSAGE": "You are an AI assistant that helps people find information.",
+        "AZURE_OPENAI_TEMPERATURE": "0",
+        "AZURE_OPENAI_TOP_P": "1.0",
+        "AZURE_RESOURCE_GROUP": "some-resource-group",
+        "AZURE_SEARCH_CONVERSATIONS_LOG_INDEX": "some-log-index",
+        "AZURE_SEARCH_CONTENT_COLUMNS": "content",
+        "AZURE_SEARCH_CONTENT_VECTOR_COLUMNS": "some-search-content-vector-columns",
+        "AZURE_SEARCH_DIMENSIONS": "some-search-dimensions",
+        "AZURE_SEARCH_ENABLE_IN_DOMAIN": "True",
+        "AZURE_SEARCH_FIELDS_ID": "some-search-fields-id",
+        "AZURE_SEARCH_FIELDS_METADATA": "some-search-fields-metadata",
+        "AZURE_SEARCH_FIELDS_TAG": "some-search-fields-tag",
+        "AZURE_SEARCH_FILENAME_COLUMN": "filepath",
+        "AZURE_SEARCH_FILTER": "some-search-filter",
+        "AZURE_SEARCH_INDEX": "some-azure-search-index",
+        "AZURE_SEARCH_INDEX_IS_PRECHUNKED": "some-azure-search-index-is-prechunked",
+        "AZURE_SEARCH_KEY": "some-azure-search-key",
+        "AZURE_SEARCH_SERVICE": "some-azure-search-service",
+        "AZURE_SEARCH_SEMANTIC_SEARCH_CONFIG": "some-search-semantic-search-config",
+        "AZURE_SEARCH_TITLE_COLUMN": "title",
+        "AZURE_SEARCH_TOP_K": "5",
+        "AZURE_SEARCH_URL_COLUMN": "url",
+        "AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION": "False",
+        "AZURE_SEARCH_USE_SEMANTIC_SEARCH": "False",
+        "AZURE_SPEECH_REGION_ENDPOINT": "some-speech-region-endpoint",
+        "AZURE_SPEECH_SERVICE_KEY": "some-azure-speech-service-key",
+        "AZURE_SPEECH_SERVICE_NAME": "some-speech-service-name",
+        "AZURE_SPEECH_SERVICE_REGION": "some-azure-speech-service-region",
+        "AZURE_SUBSCRIPTION_ID": "some-subscription-id",
+        "BACKEND_URL": "some-backend-url",
+        "DOCUMENT_PROCESSING_QUEUE_NAME": "some-document-processing-queue-name",
+        "FUNCTION_KEY": "some-function-key",
         "LOAD_CONFIG_FROM_BLOB_STORAGE": "False",
+        "LOGLEVEL": "DEBUG",
+        "ORCHESTRATION_STRATEGY": "openai_function",
+        "SPEECH_RECOGNIZER_LANGUAGES": "en-US,es-ES",
         "TIKTOKEN_CACHE_DIR": f"{os.path.dirname(os.path.realpath(__file__))}/resources",
+        "USE_KEY_VAULT": "False",
         # These values are set directly within EnvHelper, adding them here ensures
         # that they are removed from the environment when remove_from_environment() runs
         "OPENAI_API_TYPE": None,
@@ -43,6 +87,10 @@ class AppConfig:
 
     def apply_to_environment(self) -> None:
         for key, value in self.config.items():
+            current_config = os.environ.get(key)
+            if current_config is not None:
+                self.before_config[key] = current_config
+
             if value is not None:
                 logger.info(f"Applying env var: {key}={value}")
                 os.environ[key] = value
@@ -52,5 +100,9 @@ class AppConfig:
 
     def remove_from_environment(self) -> None:
         for key in self.config.keys():
-            logger.info(f"Removing env var: {key}")
-            os.environ.pop(key, None)
+            if key in self.before_config:
+                logger.info(f"Resetting env var: {key}")
+                os.environ[key] = self.before_config[key]
+            else:
+                logger.info(f"Removing env var: {key}")
+                os.environ.pop(key, None)

--- a/code/tests/functional/backend_api/tests/without_data/conftest.py
+++ b/code/tests/functional/backend_api/tests/without_data/conftest.py
@@ -24,6 +24,9 @@ def app_config(make_httpserver, ca):
     with ca.cert_pem.tempfile() as ca_temp_path:
         app_config = AppConfig(
             {
+                "AZURE_SEARCH_SERVICE": None,
+                "AZURE_SEARCH_INDEX": None,
+                "AZURE_SEARCH_KEY": None,
                 "AZURE_OPENAI_ENDPOINT": f"https://localhost:{make_httpserver.port}/",
                 "AZURE_CONTENT_SAFETY_ENDPOINT": f"https://localhost:{make_httpserver.port}/",
                 "SSL_CERT_FILE": ca_temp_path,


### PR DESCRIPTION
- Tests were failing locally for me due to a clash with azd env vars
- Change to set ALL env vars used
- This stops any predefined env vars from setting things we don't want
  in functional tests e.g. Key Vault
- Also ensure previous env vars are restored after tests
