### PR TITLE
Fix the tag to include the registry name on the docker github aworkflows.

### DIFF
--- a/.github/workflows/build-docker-admin.yml
+++ b/.github/workflows/build-docker-admin.yml
@@ -37,5 +37,5 @@ jobs:
         push: true
         cache-from: type=registry,ref=fruoccopublic.azurecr.io/rag-adminwebapp:latest
         tags: |
-          rag-adminwebapp:latest
-          rag-adminwebapp:${{ steps.date.outputs.date }}_${{ github.run_number }}
+          fruoccopublic.azurecr.io/rag-adminwebapp:latest
+          fruoccopublic.azurecr.io/rag-adminwebapp:${{ steps.date.outputs.date }}_${{ github.run_number }}

--- a/.github/workflows/build-docker-backend.yml
+++ b/.github/workflows/build-docker-backend.yml
@@ -37,5 +37,5 @@ jobs:
         push: true
         cache-from: type=registry,ref=fruoccopublic.azurecr.io/rag-backend:latest
         tags: |
-          rag-backend:latest
-          rag-backend:${{ steps.date.outputs.date }}_${{ github.run_number }}
+          fruoccopublic.azurecr.io/rag-backend:latest
+          fruoccopublic.azurecr.io/rag-backend:${{ steps.date.outputs.date }}_${{ github.run_number }}

--- a/.github/workflows/build-docker-frontend.yml
+++ b/.github/workflows/build-docker-frontend.yml
@@ -1,12 +1,14 @@
 name: WebApp Docker Image
 
 on:
-  push:
-    branches:
-      - docker-build-github-action
+  workflow_run:
+    workflows: [Tests]
+    types: [completed]
+    branches: [main]
 
 jobs:
   docker-build-frontend:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/build-docker-frontend.yml
+++ b/.github/workflows/build-docker-frontend.yml
@@ -1,14 +1,12 @@
 name: WebApp Docker Image
 
 on:
-  workflow_run:
-    workflows: [Tests]
-    types: [completed]
-    branches: [main]
+  push:
+    branches:
+      - docker-build-github-action
 
 jobs:
   docker-build-frontend:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -36,5 +34,5 @@ jobs:
         push: true
         cache-from: type=registry,ref=fruoccopublic.azurecr.io/rag-webapp:latest
         tags: |
-          rag-webapp:latest
-          rag-webapp:${{ steps.date.outputs.date }}_${{ github.run_number }}
+          fruoccopublic.azurecr.io/rag-webapp:latest
+          fruoccopublic.azurecr.io/rag-webapp:${{ steps.date.outputs.date }}_${{ github.run_number }}


### PR DESCRIPTION
## Purpose
This PR corrects the tags in the docker github workflows so that they are pushed to the right registry. Required by #605 


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x ] Other... Fixes the CI/CD config
```

## How to Test
The passing build on my feature branch, including the push step is here: https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/actions/runs/8751927224/job/24018560508

(Compare with failing https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/actions/runs/8750849851/job/24015217486 which was trying to push to Docker hub instead)