### PR TITLE
Make docker login conditional on push for docker github actions.

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -20,7 +20,7 @@ on:
         type: boolean
     secrets:
       DOCKER_PASSWORD:
-        required: true
+        required: false
 
 jobs:
   docker-build:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -31,6 +31,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Docker Login
+      if: ${{ inputs.push }}
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.registry }}


### PR DESCRIPTION
## Purpose
Changing the build-without-push github action to only run the docker login step if we need to push. 
Rationale: We don't need to do this if we aren't pushing, plus forcing docker login on every PR breaks the builds for forks which don't have the docker password secret. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ x] Other... CI/CD config update
```

## How to Test
Verify the docker builds on this PR. 