### PR TITLE
Create bicep-audit workflow

### DIFF
--- a/.github/workflows/bicep-audit.yml
+++ b/.github/workflows/bicep-audit.yml
@@ -1,0 +1,35 @@
+name: Validate bicep templates
+on:
+  push:
+    branches: 
+      - main
+    paths:
+      - "**/*.bicep"
+  pull_request:
+    branches: 
+      - main
+    paths:
+      - "**/*.bicep"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Microsoft Security DevOps Analysis
+        uses: microsoft/security-devops-action@preview
+        id: msdo
+        continue-on-error: true
+        with:
+          tools: templateanalyzer
+
+      - name: Upload alerts to Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: github.repository_owner == 'Azure-Samples'
+        with:
+          sarif_file: ${{ steps.msdo.outputs.sarifFile }}


### PR DESCRIPTION
Adds bicep audits to the GitHub workflows and uploads results to github security.

This pull request introduces a new GitHub Actions workflow that validates bicep templates. The workflow is triggered on push and pull request events to the `main` branch, specifically for changes to `.bicep` files. It runs on the latest Ubuntu environment and uses the `microsoft/security-devops-action@preview` action to analyze the templates. If the repository owner is 'Azure-Samples', it uploads the analysis results to the Security tab using the `github/codeql-action/upload-sarif@v3` action.

* [`.github/workflows/bicep-audit.yml`](diffhunk://#diff-dcd02a3340d2c1100a6c1d18a9ce9201fd1f7c78692a1d91467248fb73787bbaR1-R35): Added a new GitHub Actions workflow that validates bicep templates on push and pull request events to the `main` branch. The workflow uses the `microsoft/security-devops-action@preview` action for analysis and the `github/codeql-action/upload-sarif@v3` action to upload the analysis results to the Security tab if the repository owner is 'Azure-Samples'.