### PR TITLE
Add Reset configuration button to Admin app

### DIFF
--- a/code/backend/batch/utilities/helpers/ConfigHelper.py
+++ b/code/backend/batch/utilities/helpers/ConfigHelper.py
@@ -163,3 +163,8 @@ class ConfigHelper:
                 )
 
         return ConfigHelper._default_config
+
+    @staticmethod
+    def delete_config():
+        blob_client = AzureBlobStorageClient(container_name=CONFIG_CONTAINER_NAME)
+        blob_client.delete_file(CONFIG_FILE_NAME)

--- a/code/backend/pages/04_Configuration.py
+++ b/code/backend/pages/04_Configuration.py
@@ -340,5 +340,16 @@ try:
         ConfigHelper.save_config_as_active(current_config)
         st.success("Configuration saved successfully!")
 
+    with st.popover(":red[Reset confiiguration to defaults]"):
+        st.write(
+            "**Resetting the configuration cannot be reversed, proceed with caution!**"
+        )
+        name = st.text_input('Enter "reset" to proceed', key="reset_configuration")
+        if st.button(
+            ":red[Reset]", disabled=st.session_state["reset_configuration"] != "reset"
+        ):
+            ConfigHelper.delete_config()
+            st.success("Configuration reset successfully! Refresh to update.")
+
 except Exception:
     st.error(traceback.format_exc())

--- a/code/tests/utilities/test_ConfigHelper.py
+++ b/code/tests/utilities/test_ConfigHelper.py
@@ -194,6 +194,17 @@ def test_save_config_as_active(
     )
 
 
+def test_delete_config(AzureBlobStorageClientMock: MagicMock):
+    # when
+    ConfigHelper.delete_config()
+
+    # then
+    AzureBlobStorageClientMock.assert_called_once_with(container_name="config")
+    AzureBlobStorageClientMock.return_value.delete_file.assert_called_once_with(
+        "active.json"
+    )
+
+
 def test_get_available_document_types(config_mock: Config):
     # when
     document_types = config_mock.get_available_document_types()


### PR DESCRIPTION
Closes #738 

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Adds `Reset confiiguration to defaults` button so the configuration can be reset to the default.

It was observed when implementing #706 that there was not an easy way to reset the configuration once it had been modified, other than going into the source code.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Run admin app locally

https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/assets/60179183/d7faeb3e-d2a4-4fe4-8c61-d1622888c5a2


