### PR TITLE
Enforced LF line endings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 max-line-length = 88
 extend-ignore = E203, E501
+exclude = .venv

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,15 @@ include $(AZURE_ENV_FILE)
 help: ## 💬 This help message :)
 	@grep -E '[a-zA-Z_-]+:.*?## .*$$' $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-23s\033[0m %s\n", $$1, $$2}'
 
-ci: lint unittest functionaltest build-frontend unittest-frontend ## 🚀 Continuous Integration (called by Github Actions)
+ci: lint unittest functionaltest frontendtest ## 🚀 Continuous Integration (called by Github Actions)
 
 lint: ## 🧹 Lint the code
 	@echo -e "\e[34m$@\e[0m" || true
 	@poetry run flake8 code
+
+build-frontend: ## 🏗️ Build the Frontend webapp
+	@echo -e "\e[34m$@\e[0m" || true
+	@cd code/frontend && npm install && npm run build
 
 unittest: ## 🧪 Run the unit tests
 	@echo -e "\e[34m$@\e[0m" || true
@@ -38,11 +42,7 @@ uitest: ## 🧪 Run the ui tests in headless mode
 	@echo -e "\e[34m$@\e[0m" || true
 	@cd tests/integration/ui && npm install && npx cypress run --env ADMIN_WEBSITE_NAME=$(ADMIN_WEBSITE_NAME),FRONTEND_WEBSITE_NAME=$(FRONTEND_WEBSITE_NAME)
 
-build-frontend: ## 🏗️ Build the Frontend webapp
-	@echo -e "\e[34m$@\e[0m" || true
-	@cd code/frontend && npm install && npm run build
-
-unittest-frontend: build-frontend ## 🏗️ Unit test the Frontend webapp
+frontendtest: build-frontend ## 🧪 Unit test the Frontend webapp
 	@echo -e "\e[34m$@\e[0m" || true
 	@cd code/frontend && npm run test
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ include $(AZURE_ENV_FILE)
 help: ## 💬 This help message :)
 	@grep -E '[a-zA-Z_-]+:.*?## .*$$' $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-23s\033[0m %s\n", $$1, $$2}'
 
-ci: lint unittest functionaltest frontendtest ## 🚀 Continuous Integration (called by Github Actions)
+ci: lint unittest unittest-frontend functionaltest ## 🚀 Continuous Integration (called by Github Actions)
 
 lint: ## 🧹 Lint the code
 	@echo -e "\e[34m$@\e[0m" || true
@@ -34,6 +34,10 @@ unittest: ## 🧪 Run the unit tests
 	@echo -e "\e[34m$@\e[0m" || true
 	@poetry run pytest -m "not azure and not functional" $(optional_args)
 
+unittest-frontend: build-frontend ## 🧪 Unit test the Frontend webapp
+	@echo -e "\e[34m$@\e[0m" || true
+	@cd code/frontend && npm run test
+
 functionaltest: ## 🧪 Run the functional tests
 	@echo -e "\e[34m$@\e[0m" || true
 	@ poetry run pytest -m "functional"
@@ -41,10 +45,6 @@ functionaltest: ## 🧪 Run the functional tests
 uitest: ## 🧪 Run the ui tests in headless mode
 	@echo -e "\e[34m$@\e[0m" || true
 	@cd tests/integration/ui && npm install && npx cypress run --env ADMIN_WEBSITE_NAME=$(ADMIN_WEBSITE_NAME),FRONTEND_WEBSITE_NAME=$(FRONTEND_WEBSITE_NAME)
-
-frontendtest: build-frontend ## 🧪 Unit test the Frontend webapp
-	@echo -e "\e[34m$@\e[0m" || true
-	@cd code/frontend && npm run test
 
 docker-compose-up: ## 🐳 Run the docker-compose file
 	@cd docker && AZD_ENV_FILE=$(AZURE_ENV_FILE) docker-compose up


### PR DESCRIPTION
A user has reported that they are getting CRLF on a bash file. I do not see this on mine, but in order to fix #742 we can enforce line endings from git.

Whilst there I noticed that `make lint` was throwing errors so I have excluded the `.venv` directory as this is a generated folder. I have also removed the extra `build-frontend` that was being called in `ci`