### PR TITLE
Add prefix to dependabot commit message

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,18 +8,26 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "build"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "build"
     open-pull-requests-limit: 50
   - package-ecosystem: "npm"
     directory: "/code/frontend"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "build"
     open-pull-requests-limit: 50
   - package-ecosystem: "npm"
     directory: "/tests/integration/ui"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "build"
     open-pull-requests-limit: 50


### PR DESCRIPTION
## Purpose
Since we'll soon be adopting conventional commit messages, this change updates the Dependabot commit-message to prefix it with "build" so that it will meet the conventional commit format. The effect of this change on Dependabot PR naming will be for example,

Before:
> Bump openai from 1.24.0 to 1.26.0 

After:
> build: Bump openai from 1.24.0 to 1.26.0 

## Does this introduce a breaking change?
- [ ] Yes
- [x] No


## Pull Request Type
What kind of change does this Pull Request introduce?
- [ ] Bugfix
- [ ] Feature
- [X] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## How to Test
I have based this change on [this blog post](https://dev.to/aloisseckar/keeping-dependencies-in-your-github-projects-up-to-date-with-dependabot-16bg), which has [this example dependabot.yml](https://github.com/AloisSeckar/demos-nuxt/blob/main/.github/dependabot.yml) which produces [these pull requests](https://github.com/AloisSeckar/demos-nuxt/pulls). I will need to verify the formatting is correct when the next PRs are raised by dependabot.

## Other Information
- [Dependabot commit-message docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message)
- I opted to use "build" as the type based on [this discussion](https://stackoverflow.com/questions/65855111/what-would-be-a-good-commit-message-for-updating-package-versions-using-conventi)

Resolves #829 