### PR TITLE
build: Boolean only accepting a false is causing bicep ERROR in CI

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -84,10 +84,7 @@ param azureSearchTitleColumn string = 'title'
 @description('Url column')
 param azureSearchUrlColumn string = 'url'
 
-@description('Use Azure Search Integrated Vectorization (Not yet implemented)')
-@allowed([
-  false
-])
+@description('Use Azure Search Integrated Vectorization')
 param azureSearchUseIntegratedVectorization bool = false
 
 @description('Name of Azure OpenAI Resource')

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.26.170.59819",
-      "templateHash": "13417848583364624457"
+      "templateHash": "4288468819912019537"
     }
   },
   "parameters": {
@@ -172,11 +172,8 @@
     "azureSearchUseIntegratedVectorization": {
       "type": "bool",
       "defaultValue": false,
-      "allowedValues": [
-        false
-      ],
       "metadata": {
-        "description": "Use Azure Search Integrated Vectorization (Not yet implemented)"
+        "description": "Use Azure Search Integrated Vectorization"
       }
     },
     "azureOpenAIResourceName": {


### PR DESCRIPTION
## Purpose
Fix the broken CI. According to the logs, we have this error. I believe it is because we define it as a bool, but we only allow "false" as a value.

```
  /workspaces/chat-with-your-data-solution-accelerator/infra/main.bicepparam(29,47) : Error BCP033: Expected a value of type "false" but the provided value is of type "bool".
```

I am however unsure why this passed the previous build!