### PR TITLE
ci: Adds merge group event to PR title checker

### DIFF
--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - synchronize
+  merge_group:
 
 permissions:
   pull-requests: read
@@ -14,6 +15,7 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'merge_group' }}
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:


### PR DESCRIPTION
## Purpose
Currently the PR title checker is not mandatory, so this PR adds the `merge_group` workflow trigger to include it as a mandatory check.
However, as described [here](https://github.com/amannn/action-semantic-pull-request/issues/236), the Action only runs when triggered by `pull_request_target` or `pull_request` events. 
The solution is to have it included in the merge_group event, but not triggered by it, as described [in this comment](https://github.com/amannn/action-semantic-pull-request/issues/236#issuecomment-1695654373).

Resolves #859 

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

- [ ] Bugfix (`fix`)
- [ ] Feature (`feat`)
- [ ] Code style update (formatting, local variables) (`style`)
- [ ] Refactoring (no functional changes, no api changes) (`refactor`)
- [ ] Documentation content changes (`docs`)
- [x] Other... Please describe: CI change