### PR TITLE
build: Bullseye -> bookworm

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,4 @@
-FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/python:1-3.11-bullseye
-# We need to force the container to be amd so that it works on a Mac. Without this the functions extension doesn't install.
+FROM mcr.microsoft.com/devcontainers/python:3.11
 
 # install git
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,9 +7,7 @@
 		"ghcr.io/devcontainers/features/azure-cli:1": {},
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
 		"ghcr.io/devcontainers/features/node:1": {},
-		"ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {
-			"version": "4.0.5530"
-		},
+		"ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {},
 		"ghcr.io/azure/azure-dev/azd:latest": {},
 		"ghcr.io/rchaganti/vsc-devcontainer-features/azurebicep:1.0.5": {}
 	},


### PR DESCRIPTION
## Purpose
There was a problem with the Functions Core Tools that the compression was not working.  This meant that we had to tag the version we used.

By not defining that we have to run on Bullseye and use Bookworm (debian 12) instead, we no longer need to pin that version. Testing that this works on Windows first and then seeing if we can get Mac to work on top of this.

Relates to #866 

Please bear in mind that you will need to "rebuild" your devcontainer


After:
```sh
❯ cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
❯ azd version
azd version 1.9.2 (commit c58b02f71710960aba28f81f3698e64cfdda9f96)
❯ func version
4.0.5700
```
