### PR TITLE
fix: Add `max_tokens` to chat completions

### DIFF
--- a/code/backend/batch/utilities/helpers/llm_helper.py
+++ b/code/backend/batch/utilities/helpers/llm_helper.py
@@ -30,7 +30,7 @@ class LLMHelper:
 
         self.llm_model = self.env_helper.AZURE_OPENAI_MODEL
         self.llm_max_tokens = (
-            self.env_helper.AZURE_OPENAI_MAX_TOKENS
+            int(self.env_helper.AZURE_OPENAI_MAX_TOKENS)
             if self.env_helper.AZURE_OPENAI_MAX_TOKENS != ""
             else None
         )
@@ -121,6 +121,7 @@ class LLMHelper:
         return self.openai_client.chat.completions.create(
             model=model or self.llm_model,
             messages=messages,
+            max_tokens=self.llm_max_tokens,
         )
 
     def get_sk_chat_completion_service(self, service_id: str):

--- a/code/tests/functional/tests/backend_api/sk_orchestrator/test_response_with_text_processing_tool.py
+++ b/code/tests/functional/tests/backend_api/sk_orchestrator/test_response_with_text_processing_tool.py
@@ -174,6 +174,7 @@ def test_post_makes_correct_call_to_openai_chat_completions_in_text_processing_t
                     },
                 ],
                 "model": app_config.get("AZURE_OPENAI_MODEL"),
+                "max_tokens": int(app_config.get("AZURE_OPENAI_MAX_TOKENS")),
             },
             headers={
                 "Accept": "application/json",

--- a/code/tests/functional/tests/functions/test_advanced_image_processing.py
+++ b/code/tests/functional/tests/functions/test_advanced_image_processing.py
@@ -156,6 +156,7 @@ If the image is mostly text, use OCR to extract the text as it is displayed in t
                     },
                 ],
                 "model": app_config.get("AZURE_OPENAI_VISION_MODEL"),
+                "max_tokens": int(app_config.get("AZURE_OPENAI_MAX_TOKENS")),
             },
             headers={
                 "Accept": "application/json",


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* GPT-4 has a default max tokens of 16, meaning the captions generated were very small. This PR adds the `AZURE_OPENAI_MAX_TOKENS` to the chat completions call, so it will default to 1000 tokens, and can be conifgured.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## How to Test
* Enable Advanced Image Processing
* Upload image
* View caption in Azure Search