### PR TITLE
fix: Error viewing images in Explore Data page

### DIFF
--- a/code/backend/batch/utilities/search/azure_search_handler.py
+++ b/code/backend/batch/utilities/search/azure_search_handler.py
@@ -29,7 +29,8 @@ class AzureSearchHandler(SearchHandlerBase):
         if results is None:
             return []
         data = [
-            [json.loads(result["metadata"])["chunk"], result["content"]]
+            # Note that images uploaded with advanced image processing do not have a chunk ID, therefore we default to 0
+            [json.loads(result["metadata"]).get("chunk", 0), result["content"]]
             for result in results
         ]
         return data


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixes error where images uploaded with advanced image processing do not display in the Admin app, as they do not have a chunk ID in their metadata
* The fix is to default to chunk ID 0 when rednering the data

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## How to Test
* Enable advanced image processing
* Upload image
* View data in Explore Data page

![image](https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/assets/60179183/8813ecfd-4b55-40b1-af5b-a2d0d1b310be)
