### PR TITLE
fix: EnvHelper unusable if error occurs during initialisation

### DIFF
--- a/code/backend/batch/utilities/helpers/env_helper.py
+++ b/code/backend/batch/utilities/helpers/env_helper.py
@@ -15,8 +15,9 @@ class EnvHelper:
     def __new__(cls):
         with cls._lock:
             if cls._instance is None:
-                cls._instance = super(EnvHelper, cls).__new__(cls)
-                cls._instance.__load_config()
+                instance = super(EnvHelper, cls).__new__(cls)
+                instance.__load_config()
+                cls._instance = instance
             return cls._instance
 
     def __load_config(self, **kwargs) -> None:

--- a/code/tests/utilities/helpers/test_env_helper.py
+++ b/code/tests/utilities/helpers/test_env_helper.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from pytest import MonkeyPatch
 import pytest
 from backend.batch.utilities.helpers.env_helper import EnvHelper
@@ -140,3 +141,16 @@ def test_use_advanced_image_processing(monkeypatch: MonkeyPatch, value, expected
 
     # then
     assert actual_use_advanced_image_processing == expected
+
+
+@patch(
+    "backend.batch.utilities.helpers.env_helper.os.getenv",
+    side_effect=Exception("Some error"),
+)
+def test_env_helper_not_created_if_error_occurs(_):
+    # when
+    with pytest.raises(Exception):
+        EnvHelper()
+
+    # then
+    assert EnvHelper._instance is None


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* If an error occurs during env helper initialisation, the helper remains in a non-working state until the app restarts. This PR fixes this, so the env helper is only saved if it is created without any errors

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->
