### PR TITLE
docs: refresh documentation for running without a devcontainer

### DIFF
--- a/docs/LOCAL_DEPLOYMENT.md
+++ b/docs/LOCAL_DEPLOYMENT.md
@@ -2,6 +2,8 @@
 
 # Local setup
 
+> **Note for macOS Developers**: If you are using macOS on Apple Silicon (ARM64) the DevContainer will **not** work. This is due to a limitation with the Azure Functions Core Tools. We recommend using the [Non DevContainer Setup](./NON_DEVCONTAINER_SETUP.md) instructions to run the accelerator locally.
+
 The easiest way to run this accelerator is in a VS Code Dev Containers, which will open the project in your local VS Code using the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers):
 
 1. Start Docker Desktop (install it if not already installed)

--- a/docs/NON_DEVCONTAINER_SETUP.md
+++ b/docs/NON_DEVCONTAINER_SETUP.md
@@ -1,54 +1,80 @@
 [Back to *Chat with your data* README](../README.md)
 
-# Project setup
+# Non-DevContainer Setup
 
-If you are unable to run this accelerator as a DevContainer or in CodeSpaces, then you will need.
+If you are unable to run this accelerator using a DevContainer or in GitHub CodeSpaces, then you will need to install the following prerequisites on your local machine.
 
-- [Visual Studio Code](https://code.visualstudio.com/)
-    - Extensions
-        - [Azure Functions](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions)
-        - [Azure Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-node-azure-pack)
-        - [Bicep](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-bicep)
-        - [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance)
-        - [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
-        - [Teams Toolkit](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension) (optional: Teams extension only)
-- Install [Node.js](https://nodejs.org/en)
-  - Install the LTS version (Recommended for Most Users)
+- A code editor. We recommend [Visual Studio Code](https://code.visualstudio.com/), with the following extensions:
+  - [Azure Functions](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions)
+  - [Azure Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-node-azure-pack)
+  - [Bicep](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-bicep)
+  - [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance)
+  - [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
+  - [Teams Toolkit](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension) **Optional**
+- [Python 3.11](https://www.python.org/downloads/release/python-3119/)
+- [Node.js LTS](https://nodejs.org/en)
+- [Azure Developer CLI](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd)
+- [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local)
 
+## Setup
+
+1. Configure your Python environment:
+
+    ```bash
+    pip install --upgrade pip
+
+    pip install poetry
+
+    # https://pypi.org/project/poetry-plugin-export/
+    pip install poetry-plugin-export
+
+    poetry env use python3.11
+
+    poetry config warnings.export false
+
+    poetry install --with dev
+    ```
+
+1. Install `pre-commit` Git hooks:
+
+    ```bash
+    poetry run pre-commit install
+    ```
+
+1. Install Node.js dependencies:
+
+    ```bash
+    (cd ./code/frontend; npm install)
+
+    (cd ./tests/integration/ui; npm install)
+    ```
+
+1. Select the Python interpreter in Visual Studio Code:
+
+    - Open the command palette (`Ctrl+Shift+P` or `Cmd+Shift+P`).
+    - Type `Python: Select Interpreter`.
+    - Select the Python 3.11 environment created by Poetry.
 
 ### Running the sample using the Azure Developer CLI (azd)
 
 The Azure Developer CLI (`azd`) is a developer-centric command-line interface (CLI) tool for creating Azure applications.
 
-You need to install it before running and deploying with the Azure Developer CLI. (If you use the devcontainer, everything is already installed)
+1. Log in to Azure using `azd`:
 
-### Windows
+  ```
+  azd auth login
+  ```
 
-```powershell
-powershell -ex AllSigned -c "Invoke-RestMethod 'https://aka.ms/install-azd.ps1' | Invoke-Expression"
-```
+1. Execute the `azd init` command to initialize the environment and enter the solution accelerator name when prompted:
 
-### Linux/MacOS
+  ```
+  azd init -t chat-with-your-data-solution-accelerator
+  ```
 
-```
-curl -fsSL https://aka.ms/install-azd.sh | bash
-```
+1. Run `azd up` to provision all the resources to Azure and deploy the code to those resources.
 
-After logging in with the following command, you will be able to use the `azd` cli to quickly provision and deploy the application.
+  ```
+  azd up
+  ```
 
-```
-azd auth login
-```
-
-Then, execute the `azd init` command to initialize the environment (You do not need to run this command if you already have the code or have opened this in a Codespace or DevContainer).
-```
-azd init -t chat-with-your-data-solution-accelerator
-```
-Enter an environment name.
-
-Then, run `azd up` to provision all the resources to Azure and deploy the code to those resources.
-```
-azd up 
-```
-
-Select your desired `subscription` and `location`. Wait a moment for the resource deployment to complete, click the website endpoint and you will see the web app page.
+  > Select your desired `subscription` and `location`. Wait a moment for the resource deployment to complete, click the website endpoint and you will see the web app page.


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request includes changes to the local setup documentation, specifically for macOS developers and those not using a DevContainer. The most significant changes include the addition of a note for macOS developers in the `LOCAL_DEPLOYMENT.md` file, and a rewrite of the `NON_DEVCONTAINER_SETUP.md` file to make it more detailed and user-friendly.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->
