### PR TITLE
ci: add conventional commit preset

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -26,7 +26,12 @@ jobs:
             ['conventional-changelog-conventionalcommits@7']
           plugins: |
             [
-              '@semantic-release/commit-analyzer',
+              [
+                "@semantic-release/commit-analyzer",
+                {
+                  "preset": "conventionalcommits"
+                }
+              ],
               [
                 "@semantic-release/release-notes-generator",
                 {


### PR DESCRIPTION
## Purpose
The `semantic-release/commit-analyzer` is used in our release Action to parse our commit history and figure out the version for the release. By default, it does not detect the `!` syntax which marks a PR as a breaking change. This meant that in our first run of the updated Action, it did not correctly bump the major version despite including a breaking change: https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/releases/tag/v1.2.0

This issue comment describes how using a preset we can use the exclamation mark functionality: https://github.com/semantic-release/semantic-release/issues/2339#issuecomment-1451987883.

This PR includes that change, and has been tested using my personal test repository. Note that, when merged, it will not bump the major version since the previous breaking change was considered in an earlier release. It should however apply to any future breaking changes.

Thank you to @cecheta for finding the thread which included the solution used here.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->
