### PR TITLE
fix: PSL-BUG-1850-Fixed

### DIFF
--- a/code/frontend/src/components/Answer/Answer.tsx
+++ b/code/frontend/src/components/Answer/Answer.tsx
@@ -45,10 +45,10 @@ export const Answer = ({
         if (citation.filepath && citation.chunk_id != null) {
             if (truncate && citation.filepath.length > filePathTruncationLimit) {
                 const citationLength = citation.filepath.length;
-                citationFilename = `${citation.filepath.substring(0, 20)}...${citation.filepath.substring(citationLength -20)} - Part ${parseInt(citation.chunk_id) + 1}`;
+                citationFilename = `${citation.filepath.substring(0, 20)}...${citation.filepath.substring(citationLength -20)} - Part ${citation.chunk_id}`;
             }
             else {
-                citationFilename = `${citation.filepath} - Part ${parseInt(citation.chunk_id) + 1}`;
+                citationFilename = `${citation.filepath} - Part ${citation.chunk_id}`;
             }
         }
         else {
@@ -97,13 +97,13 @@ export const Answer = ({
                                 onClick={handleChevronClick} iconName={chevronIsExpanded ? 'ChevronDown' : 'ChevronRight'}
                                 />
                             </Stack>
-                            
+
                         </Stack>
                     </Stack.Item>
                 )}
-                
+
                 </Stack>
-                {chevronIsExpanded && 
+                {chevronIsExpanded &&
                     <div style={{ marginTop: 8, display: "flex", flexDirection: "column", height: "100%", gap: "4px", maxWidth: "100%" }}>
                         {parsedAnswer.citations.map((citation, idx) => {
                             return (


### PR DESCRIPTION

## Purpose
Web app - Part listed as reference is not included in Citation preview panel and after fixing this bug part no will give proper citation preview panel on the right side of screen.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No


## How to Test
* If you type something in chatbot for eg. "Describe in more detail the risks from market volatility" we are getting response with the citation listed as Parts 19 and 14, respectively. This "Part" of the citation is not included in the Citation preview panel.



## What to Check
* After receiving response in chatbot click on reference link which contains part no, that part no should include in the Citation preview panel.


