### PR TITLE
fix: delete url embeddings from index when deleting from Admin website

### DIFF
--- a/code/backend/batch/utilities/search/search_handler_base.py
+++ b/code/backend/batch/utilities/search/search_handler_base.py
@@ -24,6 +24,8 @@ class SearchHandlerBase(ABC):
 
     def delete_from_index(self, blob_url) -> None:
         documents = self.search_by_blob_url(blob_url)
+        if documents is None or documents.get_count() == 0:
+            return
         files_to_delete = self.output_results(documents)
         self.delete_files(files_to_delete)
 

--- a/code/backend/pages/03_Delete_Data.py
+++ b/code/backend/pages/03_Delete_Data.py
@@ -62,15 +62,15 @@ try:
                 st.info("No files selected")
                 st.stop()
             else:
+                files_to_delete = search_handler.delete_files(
+                    selected_files,
+                )
                 blob_client = AzureBlobStorageClient()
                 blob_client.delete_files(
                     selected_files, env_helper.AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION
                 )
-                if len(selected_files) > 0:
-                    st.success(
-                        "Deleted files from storage. Deleting from the index is an asynchronous process and may take a few minutes to complete."
-                        + ", ".join([name for name, ids in selected_files.items()])
-                    )
+                if len(files_to_delete) > 0:
+                    st.success("Deleted files: " + str(files_to_delete))
 
 except Exception:
     logger.error(traceback.format_exc())


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Resolves #975 
* Deleting from index every time user deletes from Admin site

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## What to Check
Verify that the following are valid
* Deleting url or documents from Admin website deletes it from storage as well as index
* Deleting document directly from Blob Storage deletes the documents from index