### PR TITLE
feat: Set limit for advanced image processing images

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,4 +21,5 @@
     "python.testing.cwd": "${workspaceFolder}/code",
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
+    "pylint.cwd": "${workspaceFolder}/code",
 }

--- a/code/backend/batch/utilities/helpers/env_helper.py
+++ b/code/backend/batch/utilities/helpers/env_helper.py
@@ -48,7 +48,7 @@ class EnvHelper:
             "AZURE_SEARCH_INDEX_IS_PRECHUNKED", ""
         )
         self.AZURE_SEARCH_FILTER = os.getenv("AZURE_SEARCH_FILTER", "")
-        self.AZURE_SEARCH_TOP_K = int(os.getenv("AZURE_SEARCH_TOP_K", "5"))
+        self.AZURE_SEARCH_TOP_K = self.get_env_var_int("AZURE_SEARCH_TOP_K", 5)
         self.AZURE_SEARCH_ENABLE_IN_DOMAIN = (
             os.getenv("AZURE_SEARCH_ENABLE_IN_DOMAIN", "true").lower() == "true"
         )
@@ -114,8 +114,8 @@ class EnvHelper:
         self.USE_ADVANCED_IMAGE_PROCESSING = self.get_env_var_bool(
             "USE_ADVANCED_IMAGE_PROCESSING", "False"
         )
-        self.ADVANCED_IMAGE_PROCESSING_MAX_IMAGES = int(
-            os.getenv("ADVANCED_IMAGE_PROCESSING_MAX_IMAGES", "1")
+        self.ADVANCED_IMAGE_PROCESSING_MAX_IMAGES = self.get_env_var_int(
+            "ADVANCED_IMAGE_PROCESSING_MAX_IMAGES", 1
         )
         self.AZURE_COMPUTER_VISION_ENDPOINT = os.getenv(
             "AZURE_COMPUTER_VISION_ENDPOINT"
@@ -247,7 +247,10 @@ class EnvHelper:
     def get_env_var_array(self, var_name: str, default: str = ""):
         return os.getenv(var_name, default).split(",")
 
-    def get_env_var_float(self, var_name: str, default: int):
+    def get_env_var_int(self, var_name: str, default: int):
+        return int(os.getenv(var_name, default))
+
+    def get_env_var_float(self, var_name: str, default: float):
         return float(os.getenv(var_name, default))
 
     def is_auth_type_keys(self):

--- a/code/backend/batch/utilities/helpers/env_helper.py
+++ b/code/backend/batch/utilities/helpers/env_helper.py
@@ -114,6 +114,9 @@ class EnvHelper:
         self.USE_ADVANCED_IMAGE_PROCESSING = self.get_env_var_bool(
             "USE_ADVANCED_IMAGE_PROCESSING", "False"
         )
+        self.ADVANCED_IMAGE_PROCESSING_MAX_IMAGES = int(
+            os.getenv("ADVANCED_IMAGE_PROCESSING_MAX_IMAGES", "1")
+        )
         self.AZURE_COMPUTER_VISION_ENDPOINT = os.getenv(
             "AZURE_COMPUTER_VISION_ENDPOINT"
         )

--- a/code/backend/batch/utilities/tools/question_answer_tool.py
+++ b/code/backend/batch/utilities/tools/question_answer_tool.py
@@ -186,7 +186,7 @@ class QuestionAnswerTool(AnsweringToolBase):
             doc.source.replace("_SAS_TOKEN_PLACEHOLDER_", container_sas)
             for doc in source_documents
             if doc.title is not None and doc.title.split(".")[-1] in image_types
-        ]
+        ][: self.env_helper.ADVANCED_IMAGE_PROCESSING_MAX_IMAGES]
 
         return image_urls
 

--- a/code/tests/functional/app_config.py
+++ b/code/tests/functional/app_config.py
@@ -74,6 +74,7 @@ class AppConfig:
         "AZURE_SPEECH_RECOGNIZER_LANGUAGES": "en-US,es-ES",
         "TIKTOKEN_CACHE_DIR": f"{os.path.dirname(os.path.realpath(__file__))}/resources",
         "USE_ADVANCED_IMAGE_PROCESSING": "False",
+        "ADVANCED_IMAGE_PROCESSING_MAX_IMAGES": "1",
         "USE_KEY_VAULT": "False",
         # These values are set directly within EnvHelper, adding them here ensures
         # that they are removed from the environment when remove_from_environment() runs

--- a/docs/advanced_image_processing.md
+++ b/docs/advanced_image_processing.md
@@ -38,4 +38,11 @@ Once enabled, advanced image processing will be enabled for all supported image 
 
 ![image](./images/enable_advanced_image_processing.png)
 
+The `ADVANCED_IMAGE_PROCESSING_MAX_IMAGES` environment variable can be used to control the maximum number of images passed to GPT-4 vision in a single request (default is `1`).
+Increasing the number of images consumes more tokens and may result in throttled requests.
+
+```bash
+azd env set ADVANCED_IMAGE_PROCESSING_MAX_IMAGES 2
+```
+
 Advanced image processing is only used in the `custom` conversation flow and not the `byod` flow, as Azure OpenAI On Your Data only supports Ada embeddings. It is currently not possible to use advanced image processing when integrated vectorization is enabled.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -110,6 +110,9 @@ param azureOpenAIModelCapacity int = 30
 @description('Enables the use of a vision LLM and Computer Vision for embedding images')
 param useAdvancedImageProcessing bool = false
 
+@description('The maximum number of images to pass to the vision model in a single request')
+param advancedImageProcessingMaxImages int = 1
+
 @description('Azure OpenAI Vision Model Deployment Name')
 param azureOpenAIVisionModel string = 'gpt-4'
 
@@ -554,6 +557,7 @@ module web './app/web.bicep' = if (hostingModel == 'code') {
       AZURE_SPEECH_SERVICE_REGION: location
       AZURE_SPEECH_RECOGNIZER_LANGUAGES: recognizedLanguages
       USE_ADVANCED_IMAGE_PROCESSING: useAdvancedImageProcessing
+      ADVANCED_IMAGE_PROCESSING_MAX_IMAGES: advancedImageProcessingMaxImages
       ORCHESTRATION_STRATEGY: orchestrationStrategy
       CONVERSATION_FLOW: conversationFlow
       LOGLEVEL: logLevel
@@ -627,6 +631,7 @@ module web_docker './app/web.bicep' = if (hostingModel == 'container') {
       AZURE_SPEECH_SERVICE_REGION: location
       AZURE_SPEECH_RECOGNIZER_LANGUAGES: recognizedLanguages
       USE_ADVANCED_IMAGE_PROCESSING: useAdvancedImageProcessing
+      ADVANCED_IMAGE_PROCESSING_MAX_IMAGES: advancedImageProcessingMaxImages
       ORCHESTRATION_STRATEGY: orchestrationStrategy
       CONVERSATION_FLOW: conversationFlow
       LOGLEVEL: logLevel
@@ -1097,3 +1102,5 @@ output ADMIN_WEBSITE_NAME string = hostingModel == 'code'
   : adminweb_docker.outputs.WEBSITE_ADMIN_URI
 output LOGLEVEL string = logLevel
 output CONVERSATION_FLOW string = conversationFlow
+output USE_ADVANCED_IMAGE_PROCESSING bool = useAdvancedImageProcessing
+output ADVANCED_IMAGE_PROCESSING_MAX_IMAGES int = advancedImageProcessingMaxImages

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -26,6 +26,7 @@ param azureOpenAIModelName = readEnvironmentVariable('AZURE_OPENAI_MODEL_NAME', 
 param azureOpenAIModelVersion = readEnvironmentVariable('AZURE_OPENAI_MODEL_VERSION', '0613')
 param azureOpenAIModelCapacity = int(readEnvironmentVariable('AZURE_OPENAI_MODEL_CAPACITY', '30'))
 param useAdvancedImageProcessing = bool(readEnvironmentVariable('USE_ADVANCED_IMAGE_PROCESSING', 'false'))
+param advancedImageProcessingMaxImages = int(readEnvironmentVariable('ADVANCED_IMAGE_PROCESSING_MAX_IMAGES', '1'))
 param azureOpenAIVisionModel = readEnvironmentVariable('AZURE_OPENAI_VISION_MODEL', 'gpt-4')
 param azureOpenAIVisionModelName = readEnvironmentVariable('AZURE_OPENAI_VISION_MODEL_NAME', 'gpt-4')
 param azureOpenAIVisionModelVersion = readEnvironmentVariable('AZURE_OPENAI_VISION_MODEL_VERSION', 'vision-preview')

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.27.1.19265",
-      "templateHash": "6027201902589320671"
+      "templateHash": "10484197901623589764"
     }
   },
   "parameters": {
@@ -227,6 +227,13 @@
       "defaultValue": false,
       "metadata": {
         "description": "Enables the use of a vision LLM and Computer Vision for embedding images"
+      }
+    },
+    "advancedImageProcessingMaxImages": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "The maximum number of images to pass to the vision model in a single request"
       }
     },
     "azureOpenAIVisionModel": {
@@ -2031,6 +2038,7 @@
               "AZURE_SPEECH_SERVICE_REGION": "[parameters('location')]",
               "AZURE_SPEECH_RECOGNIZER_LANGUAGES": "[parameters('recognizedLanguages')]",
               "USE_ADVANCED_IMAGE_PROCESSING": "[parameters('useAdvancedImageProcessing')]",
+              "ADVANCED_IMAGE_PROCESSING_MAX_IMAGES": "[parameters('advancedImageProcessingMaxImages')]",
               "ORCHESTRATION_STRATEGY": "[parameters('orchestrationStrategy')]",
               "CONVERSATION_FLOW": "[parameters('conversationFlow')]",
               "LOGLEVEL": "[parameters('logLevel')]"
@@ -2984,6 +2992,7 @@
               "AZURE_SPEECH_SERVICE_REGION": "[parameters('location')]",
               "AZURE_SPEECH_RECOGNIZER_LANGUAGES": "[parameters('recognizedLanguages')]",
               "USE_ADVANCED_IMAGE_PROCESSING": "[parameters('useAdvancedImageProcessing')]",
+              "ADVANCED_IMAGE_PROCESSING_MAX_IMAGES": "[parameters('advancedImageProcessingMaxImages')]",
               "ORCHESTRATION_STRATEGY": "[parameters('orchestrationStrategy')]",
               "CONVERSATION_FLOW": "[parameters('conversationFlow')]",
               "LOGLEVEL": "[parameters('logLevel')]"
@@ -11102,6 +11111,14 @@
     "CONVERSATION_FLOW": {
       "type": "string",
       "value": "[parameters('conversationFlow')]"
+    },
+    "USE_ADVANCED_IMAGE_PROCESSING": {
+      "type": "bool",
+      "value": "[parameters('useAdvancedImageProcessing')]"
+    },
+    "ADVANCED_IMAGE_PROCESSING_MAX_IMAGES": {
+      "type": "int",
+      "value": "[parameters('advancedImageProcessingMaxImages')]"
     }
   }
 }


### PR DESCRIPTION
Required for #750

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Set a limit to the number of images that are passed to the LLM when using advanced image processing. Defaults to 1

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
* Deploy code, with advanced image processing enabled
* Upload similar images
* Make query about images
* Check number of images passed to LLM