### PR TITLE
fix: Text is overlapping in the citation section (Line spacing) 

### DIFF
--- a/code/frontend/src/pages/chat/Chat.module.css
+++ b/code/frontend/src/pages/chat/Chat.module.css
@@ -234,7 +234,7 @@
     color: #323130;
     margin-top: 12px;
     margin-bottom: 12px;
-} 
+}
 
 .citationPanelContent {
     font-family: "Segoe UI";
@@ -247,58 +247,64 @@
     order: 1;
     align-self: stretch;
     flex-grow: 0;
-} 
+}
 
-.MobileChatContainer{
-    @media screen and (max-width: 600px)  {
+.citationPanelContent h1 {
+
+    line-height: 30px;
+
+}
+
+.MobileChatContainer {
+    @media screen and (max-width: 600px) {
         max-width: 100%;
         margin: 0 auto;
         padding: 8px;
-        
-      }
+
+    }
 }
 
 .mobileStyles {
-    @media screen and (max-width: 600px)  {
+    @media screen and (max-width: 600px) {
         max-width: 100%;
-        flex-grow: 1; 
+        flex-grow: 1;
         max-height: 100vh;
     }
-  }
+}
 
-  .mobileclearChatBroom{
-      @media screen and (max-width: 600px)  {
+.mobileclearChatBroom {
+    @media screen and (max-width: 600px) {
         left: -30px;
-        
-      }
+
     }
-  
-    .mobileCitationPanelTitle{
-        @media screen and (max-width: 600px)  {
-            font-weight: 400;
-            font-size: 12px;
-            margin-top: 8px;
-            margin-bottom: 8px;
-            
-          }
+}
+
+.mobileCitationPanelTitle {
+    @media screen and (max-width: 600px) {
+        font-weight: 400;
+        font-size: 12px;
+        margin-top: 8px;
+        margin-bottom: 8px;
+
+    }
+}
+
+.mobileCitationPanelContent {
+    @media screen and (max-width: 600px) {
+        font-weight: 250;
+        font-size: 11px;
+
+    }
+}
+
+@media screen and (max-width: 600px) {
+    h1 {
+        font-weight: 300;
+        font-size: 14px;
     }
 
-    .mobileCitationPanelContent{
-        @media screen and (max-width: 600px){
-            font-weight: 250;
-            font-size: 11px;
-
-        } 
+    h2 {
+        font-weight: 300;
+        font-size: 12px;
     }
-
-    @media screen and (max-width: 600px){
-        h1{
-            font-weight: 300;
-            font-size: 14px;
-        }
-
-        h2{
-            font-weight: 300;
-            font-size: 12px;
-        }
-     }
+}


### PR DESCRIPTION
## Purpose
Text is overlapping in the citation section.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## How to Test
1-Type something on chat bot for e.g. "Provide the details of European Equities Fund" 
2-Click on references and select "Woodgrove Asset Mana...Management Funds.pdf - Part 81".
3-Find the text overlapping in citation section.

## What to Check
In citation section , you will see there is no overlapping text now.