### PR TITLE
fix: Login to Azure in post provision step if not already

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Welcome to the *Chat with your data* Solution accelerator repository! The *Chat 
 
 ### About this repo
 
-This repository provides an end-to-end solution for users who want to query their data with natural language. It includes a well designed ingestion mechanism for multiple file types, an easy deployment, and a support team for maintenance. The accelerator demonstrates both Push or Pull Ingestion; the choice of orchestration (Semantic Kernel, LangChain, OpenAI Functions or Prompt Flow) and should be the minimum components needed to implement a RAG pattern. It is not intended to be put into Production as-is without experimentation or evaluation of your data. It provides the following features:
+This repository provides an end-to-end solution for users who want to query their data with natural language. It includes a well designed ingestion mechanism for multiple file types, an easy deployment, and a support team for maintenance. The accelerator demonstrates both Push or Pull Ingestion; the choice of orchestration (Semantic Kernel, LangChain, OpenAI Functions or [Prompt Flow](docs/prompt_flow.md)) and should be the minimum components needed to implement a RAG pattern. It is not intended to be put into Production as-is without experimentation or evaluation of your data. It provides the following features:
 
 * Chat with an Azure OpenAI model using your own data
 * Upload and process your documents

--- a/infra/prompt-flow/create-prompt-flow.sh
+++ b/infra/prompt-flow/create-prompt-flow.sh
@@ -11,6 +11,7 @@ while IFS='=' read -r key value; do
     case "$key" in
         "ORCHESTRATION_STRATEGY") orchestration_strategy=$value ;;
         "AZURE_SUBSCRIPTION_ID") subscription_id=$value ;;
+        "AZURE_TENANT_ID") tenant_id=$value ;;
         "AZURE_RESOURCE_GROUP") resource_group=$value ;;
         "AZURE_ML_WORKSPACE_NAME") aml_workspace=$value ;;
         "RESOURCE_TOKEN") resource_token=$value ;;
@@ -62,6 +63,10 @@ sed -i "s@<openai_embedding_model>@${openai_embedding_model}@g" "$flow_dag_file"
 sed -i "s@<aisearch_connection_id>@${connection_id_prefix}/aisearch_connection@g" "$flow_dag_file"
 sed -i "s@<aisearch_endpoint>@${search_service}@g" "$flow_dag_file"
 sed -i "s@<aisearch_index>@${search_index}@g" "$flow_dag_file"
+
+# login to Azure if not already logged in
+az account show > /dev/null 2>&1 || az login --tenant "$tenant_id"
+az account set --subscription "$subscription_id"
 
 set +e
 tries=1


### PR DESCRIPTION
Relates to #406 

If you run `azd auth login` from your devcontainer, you may not have ran `az login` which means that during the Post Provision hook, the `pfazure` command can fail

## How to Test
Dont login to Azure using `az login`
run `azd up` with PromptFlow enabled
