### PR TITLE
fix: [Bug-4714-Admin] Borders for contrast mode and fixed resizing issue for 1280p

### DIFF
--- a/code/backend/Admin.py
+++ b/code/backend/Admin.py
@@ -31,31 +31,12 @@ st.set_page_config(
     menu_items=None,
 )
 
-MOD_PAGE_STYLE = """
-            <style>
-            #MainMenu {visibility: hidden;}
-            footer {visibility: hidden;}
-            header {visibility: hidden;}
-            .st-emotion-cache-1kyxreq{width:100%}
-            @media screen and (-ms-high-contrast: active), (forced-colors: active) {
-                section{
-                    border: 2px solid WindowText;padding: 10px;
-                    background-color: Window;
-                    color: WindowText;
-                }
-            }
-            @media screen and (max-width: 1280px) {
-                .st-emotion-cache-1wmy9hl .st-emotion-cache-ocqkz7  {
-                        gap: 0rem !important;
-                }
+def load_css(file_path):
+    with open(file_path) as f:
+        st.markdown(f"<style>{f.read()}</style>", unsafe_allow_html=True)
 
-                .st-emotion-cache-1kyxreq{
-                    max-width: 200px !important;
-                }
-            }
-            </style>
-            """
-st.markdown(MOD_PAGE_STYLE, unsafe_allow_html=True)
+# Load the common CSS
+load_css("pages/common.css")
 
 
 col1, col2, col3 = st.columns([1, 2, 1])

--- a/code/backend/Admin.py
+++ b/code/backend/Admin.py
@@ -36,6 +36,23 @@ MOD_PAGE_STYLE = """
             #MainMenu {visibility: hidden;}
             footer {visibility: hidden;}
             header {visibility: hidden;}
+            .st-emotion-cache-1kyxreq{width:100%}
+            @media screen and (-ms-high-contrast: active), (forced-colors: active) {
+                section{
+                    border: 2px solid WindowText;padding: 10px;
+                    background-color: Window;
+                    color: WindowText;
+                }
+            }
+            @media screen and (max-width: 1280px) {
+                .st-emotion-cache-1wmy9hl .st-emotion-cache-ocqkz7  {
+                        gap: 0rem !important;
+                }
+
+                .st-emotion-cache-1kyxreq{
+                    max-width: 200px !important;
+                }
+            }
             </style>
             """
 st.markdown(MOD_PAGE_STYLE, unsafe_allow_html=True)

--- a/code/backend/pages/common.css
+++ b/code/backend/pages/common.css
@@ -1,0 +1,20 @@
+#MainMenu {visibility: hidden;}
+footer {visibility: hidden;}
+header {visibility: hidden;}
+.st-emotion-cache-1kyxreq{width:100%}
+@media screen and (-ms-high-contrast: active), (forced-colors: active) {
+    section, .st-emotion-cache-ch5dnh{
+        border: 2px solid WindowText;padding: 10px;
+        background-color: Window;
+        color: WindowText;
+    }
+}
+@media screen and (max-width: 1280px) {
+    .st-emotion-cache-1wmy9hl .st-emotion-cache-ocqkz7  {
+            gap: 0rem !important;
+    }
+
+    .st-emotion-cache-1kyxreq{
+        max-width: 200px !important;
+    }
+}


### PR DESCRIPTION
## Purpose
**1. High contrast modes** 
Open CWYD Admin URL.
Go to system setting ->Accessibility->Contrast themes->select aquatic in drop down-> apply.
Go to CWYD Admin URL, you can find the screen, does not have separation border between left collapse and main screen.
Expected result: By providing borders to the fields.

**2. Resizing: Text in the page should be adaptable to resizing up to 200% zoom in 1280p without overlap.** 
Open CWYD Admin URL.
Go to system setting ->System->Display resolution->select 1280P in drop down-> apply.
Go to CWYD Admin URL, you can find the screen, the content is not adaptable.
Expected result: Resize of the content so that the adaptable in the above resolution.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
**1. High contrast modes** 
Open CWYD Admin URL.
Go to system setting ->Accessibility->Contrast themes->select aquatic in drop down-> apply.
Go to CWYD Admin URL, you can find the screen, does not have separation border between left collapse and main screen.


**2. Resizing: Text in the page should be adaptable to resizing up to 200% zoom in 1280p without overlap.** 
Open CWYD Admin URL.
Go to system setting ->System->Display resolution->select 1280P in drop down-> apply.
Go to CWYD Admin URL, you can find the screen, the content is not adaptable.

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

Please find attached screenshot

![image](https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/assets/168007985/3f6e3840-bb57-4fcf-a4f3-fb298b310445)

![image](https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/assets/168007985/d0eb8eab-9e21-40bf-a18b-955ee8140fab)

![image](https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/assets/168007985/9069f986-2620-4c5f-bd85-af5608ece92e)

