### PR TITLE
fix: Correctly set computer vision location

### DIFF
--- a/infra/core/ai/cognitiveservices.bicep
+++ b/infra/core/ai/cognitiveservices.bicep
@@ -8,21 +8,21 @@ param deployments array = []
 param kind string = 'OpenAI'
 param managedIdentity bool = false
 
-@allowed(['Enabled', 'Disabled'])
+@allowed([ 'Enabled', 'Disabled' ])
 param publicNetworkAccess string = 'Enabled'
 param sku object = {
   name: 'S0'
 }
 
 param allowedIpRules array = []
-param networkAcls object = empty(allowedIpRules)
-  ? {
-      defaultAction: 'Allow'
-    }
-  : {
-      ipRules: allowedIpRules
-      defaultAction: 'Deny'
-    }
+param networkAcls object = empty(allowedIpRules) 
+ ? {
+  defaultAction: 'Allow'
+} 
+ : {
+  ipRules: allowedIpRules
+  defaultAction: 'Deny'
+}
 
 resource account 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   name: name
@@ -42,23 +42,24 @@ resource account 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
 
 @batchSize(1)
 resource deployment 'Microsoft.CognitiveServices/accounts/deployments@2023-05-01' = [
-  for deployment in deployments: {
-    parent: account
-    name: deployment.name
-    properties: {
-      model: deployment.model
-      raiPolicyName: contains(deployment, 'raiPolicyName') ? deployment.raiPolicyName : null
-    }
-    sku: contains(deployment, 'sku')
-      ? deployment.sku
-      : {
-          name: 'Standard'
-          capacity: 20
-        }
+for deployment in deployments: {
+  parent: account
+  name: deployment.name
+  properties: {
+    model: deployment.model
+    raiPolicyName: contains(deployment, 'raiPolicyName') ? deployment.raiPolicyName : null
   }
+  sku: contains(deployment, 'sku') 
+   ? deployment.sku 
+   : {
+    name: 'Standard'
+    capacity: 20
+  }
+}
 ]
 
 output endpoint string = account.properties.endpoint
 output identityPrincipalId string = managedIdentity ? account.identity.principalId : ''
 output id string = account.id
 output name string = account.name
+output location string = location

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -193,7 +193,7 @@ param computerVisionSkuName string = 'S1'
   'southeastasia'
   ''
 ])
-param computerVisionLocation string = useAdvancedImageProcessing ? location : ''
+param computerVisionLocation string = ''
 
 @description('Azure Computer Vision Vectorize Image API Version')
 param computerVisionVectorizeImageApiVersion string = '2024-02-01'
@@ -338,22 +338,22 @@ var defaultOpenAiDeployments = [
 
 var openAiDeployments = concat(
   defaultOpenAiDeployments,
-  useAdvancedImageProcessing
-    ? [
-        {
-          name: azureOpenAIVisionModel
-          model: {
-            format: 'OpenAI'
-            name: azureOpenAIVisionModelName
-            version: azureOpenAIVisionModelVersion
-          }
-          sku: {
-            name: 'Standard'
-            capacity: azureOpenAIVisionModelCapacity
-          }
-        }
-      ]
-    : []
+  useAdvancedImageProcessing 
+   ? [
+    {
+      name: azureOpenAIVisionModel
+      model: {
+        format: 'OpenAI'
+        name: azureOpenAIVisionModelName
+        version: azureOpenAIVisionModelVersion
+      }
+      sku: {
+        name: 'Standard'
+        capacity: azureOpenAIVisionModelCapacity
+      }
+    }
+  ] 
+   : []
 )
 
 module openai 'core/ai/cognitiveservices.bicep' = {
@@ -377,7 +377,7 @@ module computerVision 'core/ai/cognitiveservices.bicep' = if (useAdvancedImagePr
   params: {
     name: computerVisionName
     kind: 'ComputerVision'
-    location: computerVisionLocation
+    location: computerVisionLocation != '' ? computerVisionLocation : location
     tags: tags
     sku: {
       name: computerVisionSkuName
@@ -811,9 +811,9 @@ module workbook './app/workbook.bicep' = {
     hostingPlanName: hostingplan.outputs.name
     functionName: hostingModel == 'container' ? function_docker.outputs.functionName : function.outputs.functionName
     websiteName: hostingModel == 'container' ? web_docker.outputs.FRONTEND_API_NAME : web.outputs.FRONTEND_API_NAME
-    adminWebsiteName: hostingModel == 'container'
-      ? adminweb_docker.outputs.WEBSITE_ADMIN_NAME
-      : adminweb.outputs.WEBSITE_ADMIN_NAME
+    adminWebsiteName: hostingModel == 'container' 
+     ? adminweb_docker.outputs.WEBSITE_ADMIN_NAME 
+     : adminweb.outputs.WEBSITE_ADMIN_NAME
     eventGridSystemTopicName: eventgrid.outputs.name
     logAnalyticsName: monitoring.outputs.logAnalyticsWorkspaceName
     azureOpenAIResourceName: openai.outputs.name
@@ -972,12 +972,12 @@ module storage 'core/storage/storage-account.bicep' = {
     sku: {
       name: 'Standard_GRS'
     }
-    deleteRetentionPolicy: azureSearchUseIntegratedVectorization
-      ? {
-          enabled: true
-          days: 7
-        }
-      : {}
+    deleteRetentionPolicy: azureSearchUseIntegratedVectorization 
+     ? {
+      enabled: true
+      days: 7
+    } 
+     : {}
     containers: [
       {
         name: blobContainerName
@@ -1066,6 +1066,7 @@ output AZURE_BLOB_CONTAINER_NAME string = blobContainerName
 output AZURE_BLOB_ACCOUNT_NAME string = storageAccountName
 output AZURE_BLOB_ACCOUNT_KEY string = useKeyVault ? storekeys.outputs.STORAGE_ACCOUNT_KEY_NAME : ''
 output AZURE_COMPUTER_VISION_ENDPOINT string = useAdvancedImageProcessing ? computerVision.outputs.endpoint : ''
+output AZURE_COMPUTER_VISION_LOCATION string = useAdvancedImageProcessing ? computerVision.outputs.location : ''
 output AZURE_COMPUTER_VISION_KEY string = useKeyVault ? storekeys.outputs.COMPUTER_VISION_KEY_NAME : ''
 output AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_API_VERSION string = computerVisionVectorizeImageApiVersion
 output AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_MODEL_VERSION string = computerVisionVectorizeImageModelVersion
@@ -1114,17 +1115,17 @@ output AZURE_TENANT_ID string = tenant().tenantId
 output DOCUMENT_PROCESSING_QUEUE_NAME string = queueName
 output ORCHESTRATION_STRATEGY string = orchestrationStrategy
 output USE_KEY_VAULT bool = useKeyVault
-output FRONTEND_WEBSITE_NAME string = hostingModel == 'code'
-  ? web.outputs.FRONTEND_API_URI
-  : web_docker.outputs.FRONTEND_API_URI
-output ADMIN_WEBSITE_NAME string = hostingModel == 'code'
-  ? adminweb.outputs.WEBSITE_ADMIN_URI
-  : adminweb_docker.outputs.WEBSITE_ADMIN_URI
+output FRONTEND_WEBSITE_NAME string = hostingModel == 'code' 
+ ? web.outputs.FRONTEND_API_URI 
+ : web_docker.outputs.FRONTEND_API_URI
+output ADMIN_WEBSITE_NAME string = hostingModel == 'code' 
+ ? adminweb.outputs.WEBSITE_ADMIN_URI 
+ : adminweb_docker.outputs.WEBSITE_ADMIN_URI
 output LOGLEVEL string = logLevel
 output CONVERSATION_FLOW string = conversationFlow
 output USE_ADVANCED_IMAGE_PROCESSING bool = useAdvancedImageProcessing
 output ADVANCED_IMAGE_PROCESSING_MAX_IMAGES int = advancedImageProcessingMaxImages
-output AZURE_ML_WORKSPACE_NAME string = orchestrationStrategy == 'prompt_flow'
-  ? machineLearning.outputs.workspaceName
-  : ''
+output AZURE_ML_WORKSPACE_NAME string = orchestrationStrategy == 'prompt_flow' 
+ ? machineLearning.outputs.workspaceName 
+ : ''
 output RESOURCE_TOKEN string = resourceToken

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -39,6 +39,7 @@ param azureOpenAITopP = readEnvironmentVariable('AZURE_OPENAI_TOP_P', '1')
 param azureOpenAIStopSequence = readEnvironmentVariable('AZURE_OPENAI_STOP_SEQUENCE', '\n')
 
 // Computer Vision parameters
+param computerVisionLocation = readEnvironmentVariable('AZURE_COMPUTER_VISION_LOCATION', '')
 param computerVisionVectorizeImageApiVersion = readEnvironmentVariable('AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_API_VERSION', '2024-02-01')
 param computerVisionVectorizeImageModelVersion = readEnvironmentVariable('AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_MODEL_VERSION', '2023-04-15')
 

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -39,7 +39,6 @@ param azureOpenAITopP = readEnvironmentVariable('AZURE_OPENAI_TOP_P', '1')
 param azureOpenAIStopSequence = readEnvironmentVariable('AZURE_OPENAI_STOP_SEQUENCE', '\n')
 
 // Computer Vision parameters
-param computerVisionLocation = readEnvironmentVariable('AZURE_COMPUTER_VISION_LOCATION', '')
 param computerVisionVectorizeImageApiVersion = readEnvironmentVariable('AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_API_VERSION', '2024-02-01')
 param computerVisionVectorizeImageModelVersion = readEnvironmentVariable('AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_MODEL_VERSION', '2023-04-15')
 

--- a/infra/main.json
+++ b/infra/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.27.1.19265",
-      "templateHash": "15258388180861212685"
+      "version": "0.24.24.22086",
+      "templateHash": "17715205569944758398"
     }
   },
   "parameters": {
@@ -378,7 +378,7 @@
     },
     "computerVisionLocation": {
       "type": "string",
-      "defaultValue": "[if(parameters('useAdvancedImageProcessing'), parameters('location'), '')]",
+      "defaultValue": "",
       "allowedValues": [
         "eastus",
         "westus",
@@ -645,8 +645,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "10946574055690902625"
+              "version": "0.24.24.22086",
+              "templateHash": "18288317658862179612"
             },
             "description": "Creates an Azure Key Vault."
           },
@@ -742,8 +742,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "12902207048115971201"
+              "version": "0.24.24.22086",
+              "templateHash": "10341721798739145213"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -855,6 +855,10 @@
             "name": {
               "type": "string",
               "value": "[parameters('name')]"
+            },
+            "location": {
+              "type": "string",
+              "value": "[parameters('location')]"
             }
           }
         }
@@ -881,9 +885,7 @@
           "kind": {
             "value": "ComputerVision"
           },
-          "location": {
-            "value": "[parameters('computerVisionLocation')]"
-          },
+          "location": "[if(not(equals(parameters('computerVisionLocation'), '')), createObject('value', parameters('computerVisionLocation')), createObject('value', parameters('location')))]",
           "tags": {
             "value": "[variables('tags')]"
           },
@@ -899,8 +901,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "12902207048115971201"
+              "version": "0.24.24.22086",
+              "templateHash": "10341721798739145213"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -1012,6 +1014,10 @@
             "name": {
               "type": "string",
               "value": "[parameters('name')]"
+            },
+            "location": {
+              "type": "string",
+              "value": "[parameters('location')]"
             }
           }
         }
@@ -1048,8 +1054,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "16440196655390446916"
+              "version": "0.24.24.22086",
+              "templateHash": "2184194315885104837"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -1119,8 +1125,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "16440196655390446916"
+              "version": "0.24.24.22086",
+              "templateHash": "2184194315885104837"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -1190,8 +1196,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "16440196655390446916"
+              "version": "0.24.24.22086",
+              "templateHash": "2184194315885104837"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -1261,8 +1267,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "16440196655390446916"
+              "version": "0.24.24.22086",
+              "templateHash": "2184194315885104837"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -1336,8 +1342,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "12902207048115971201"
+              "version": "0.24.24.22086",
+              "templateHash": "10341721798739145213"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -1449,6 +1455,10 @@
             "name": {
               "type": "string",
               "value": "[parameters('name')]"
+            },
+            "location": {
+              "type": "string",
+              "value": "[parameters('location')]"
             }
           }
         }
@@ -1501,8 +1511,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "2723102221602621788"
+              "version": "0.24.24.22086",
+              "templateHash": "16225298272147969349"
             }
           },
           "parameters": {
@@ -1714,8 +1724,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "109530586617035708"
+              "version": "0.24.24.22086",
+              "templateHash": "6777557730842559074"
             },
             "description": "Creates an Azure AI Search instance."
           },
@@ -1883,8 +1893,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "3882056790487836425"
+              "version": "0.24.24.22086",
+              "templateHash": "6658410551007142152"
             },
             "description": "Creates an Azure App Service plan."
           },
@@ -2063,8 +2073,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "3523301306282440498"
+              "version": "0.24.24.22086",
+              "templateHash": "15498035769847489288"
             }
           },
           "parameters": {
@@ -2241,8 +2251,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "13528682982724980465"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2853975730522685185"
                     },
                     "description": "Creates an Azure App Service in an existing Azure App Service plan."
                   },
@@ -2468,8 +2478,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.27.1.19265",
-                              "templateHash": "9730065891606131364"
+                              "version": "0.24.24.22086",
+                              "templateHash": "16186931945900992707"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -2546,8 +2556,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -2615,8 +2625,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -2684,8 +2694,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -2753,8 +2763,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -2819,8 +2829,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "6278079210023281106"
+                      "version": "0.24.24.22086",
+                      "templateHash": "5336116590814097384"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -3017,8 +3027,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "3523301306282440498"
+              "version": "0.24.24.22086",
+              "templateHash": "15498035769847489288"
             }
           },
           "parameters": {
@@ -3195,8 +3205,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "13528682982724980465"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2853975730522685185"
                     },
                     "description": "Creates an Azure App Service in an existing Azure App Service plan."
                   },
@@ -3422,8 +3432,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.27.1.19265",
-                              "templateHash": "9730065891606131364"
+                              "version": "0.24.24.22086",
+                              "templateHash": "16186931945900992707"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -3500,8 +3510,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -3569,8 +3579,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -3638,8 +3648,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -3707,8 +3717,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -3773,8 +3783,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "6278079210023281106"
+                      "version": "0.24.24.22086",
+                      "templateHash": "5336116590814097384"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -3970,8 +3980,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "9122829587959554559"
+              "version": "0.24.24.22086",
+              "templateHash": "3807551112726378511"
             }
           },
           "parameters": {
@@ -4141,8 +4151,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "13528682982724980465"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2853975730522685185"
                     },
                     "description": "Creates an Azure App Service in an existing Azure App Service plan."
                   },
@@ -4368,8 +4378,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.27.1.19265",
-                              "templateHash": "9730065891606131364"
+                              "version": "0.24.24.22086",
+                              "templateHash": "16186931945900992707"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -4446,8 +4456,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -4515,8 +4525,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -4584,8 +4594,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -4653,8 +4663,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -4719,8 +4729,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "6278079210023281106"
+                      "version": "0.24.24.22086",
+                      "templateHash": "5336116590814097384"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -4913,8 +4923,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "9122829587959554559"
+              "version": "0.24.24.22086",
+              "templateHash": "3807551112726378511"
             }
           },
           "parameters": {
@@ -5084,8 +5094,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "13528682982724980465"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2853975730522685185"
                     },
                     "description": "Creates an Azure App Service in an existing Azure App Service plan."
                   },
@@ -5311,8 +5321,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.27.1.19265",
-                              "templateHash": "9730065891606131364"
+                              "version": "0.24.24.22086",
+                              "templateHash": "16186931945900992707"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -5389,8 +5399,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -5458,8 +5468,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -5527,8 +5537,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -5596,8 +5606,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -5662,8 +5672,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "6278079210023281106"
+                      "version": "0.24.24.22086",
+                      "templateHash": "5336116590814097384"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -5777,8 +5787,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "13065021834937678877"
+              "version": "0.24.24.22086",
+              "templateHash": "1447821869691449548"
             },
             "description": "Creates an Application Insights instance and a Log Analytics workspace."
           },
@@ -5829,8 +5839,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "2707024492396982954"
+                      "version": "0.24.24.22086",
+                      "templateHash": "7303134511679605290"
                     },
                     "description": "Creates a Log Analytics workspace."
                   },
@@ -5910,8 +5920,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "6684811037284796150"
+                      "version": "0.24.24.22086",
+                      "templateHash": "7876824876150965509"
                     },
                     "description": "Creates an Application Insights instance based on an existing Log Analytics workspace."
                   },
@@ -5975,8 +5985,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.27.1.19265",
-                              "templateHash": "1759216242890853910"
+                              "version": "0.24.24.22086",
+                              "templateHash": "17844342106049583039"
                             },
                             "description": "Creates a dashboard for an Application Insights instance."
                           },
@@ -7314,8 +7324,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "5649433306021197168"
+              "version": "0.24.24.22086",
+              "templateHash": "11939728038427453906"
             }
           },
           "parameters": {
@@ -7397,8 +7407,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "2792566012892132891"
+                      "version": "0.24.24.22086",
+                      "templateHash": "5276699956994257721"
                     }
                   },
                   "parameters": {
@@ -7583,8 +7593,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "14690928021789276012"
+              "version": "0.24.24.22086",
+              "templateHash": "12007300634992115174"
             }
           },
           "parameters": {
@@ -7772,8 +7782,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "4546396046228166655"
+                      "version": "0.24.24.22086",
+                      "templateHash": "18381130642630574187"
                     },
                     "description": "Creates an Azure Function in an existing Azure App Service plan."
                   },
@@ -7980,8 +7990,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.27.1.19265",
-                              "templateHash": "13528682982724980465"
+                              "version": "0.24.24.22086",
+                              "templateHash": "2853975730522685185"
                             },
                             "description": "Creates an Azure App Service in an existing Azure App Service plan."
                           },
@@ -8207,8 +8217,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.27.1.19265",
-                                      "templateHash": "9730065891606131364"
+                                      "version": "0.24.24.22086",
+                                      "templateHash": "16186931945900992707"
                                     },
                                     "description": "Updates app settings for an Azure App Service."
                                   },
@@ -8303,8 +8313,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -8372,8 +8382,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -8441,8 +8451,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -8510,8 +8520,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -8579,8 +8589,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -8645,8 +8655,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "6278079210023281106"
+                      "version": "0.24.24.22086",
+                      "templateHash": "5336116590814097384"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -8818,8 +8828,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "14690928021789276012"
+              "version": "0.24.24.22086",
+              "templateHash": "12007300634992115174"
             }
           },
           "parameters": {
@@ -9007,8 +9017,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "4546396046228166655"
+                      "version": "0.24.24.22086",
+                      "templateHash": "18381130642630574187"
                     },
                     "description": "Creates an Azure Function in an existing Azure App Service plan."
                   },
@@ -9215,8 +9225,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.27.1.19265",
-                              "templateHash": "13528682982724980465"
+                              "version": "0.24.24.22086",
+                              "templateHash": "2853975730522685185"
                             },
                             "description": "Creates an Azure App Service in an existing Azure App Service plan."
                           },
@@ -9442,8 +9452,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.27.1.19265",
-                                      "templateHash": "9730065891606131364"
+                                      "version": "0.24.24.22086",
+                                      "templateHash": "16186931945900992707"
                                     },
                                     "description": "Updates app settings for an Azure App Service."
                                   },
@@ -9538,8 +9548,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -9607,8 +9617,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -9676,8 +9686,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -9745,8 +9755,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -9814,8 +9824,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "16440196655390446916"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2184194315885104837"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -9880,8 +9890,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "6278079210023281106"
+                      "version": "0.24.24.22086",
+                      "templateHash": "5336116590814097384"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -9986,8 +9996,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "12902207048115971201"
+              "version": "0.24.24.22086",
+              "templateHash": "10341721798739145213"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -10099,6 +10109,10 @@
             "name": {
               "type": "string",
               "value": "[parameters('name')]"
+            },
+            "location": {
+              "type": "string",
+              "value": "[parameters('location')]"
             }
           }
         }
@@ -10137,8 +10151,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "12902207048115971201"
+              "version": "0.24.24.22086",
+              "templateHash": "10341721798739145213"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -10250,6 +10264,10 @@
             "name": {
               "type": "string",
               "value": "[parameters('name')]"
+            },
+            "location": {
+              "type": "string",
+              "value": "[parameters('location')]"
             }
           }
         }
@@ -10291,8 +10309,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "7008837948540418623"
+              "version": "0.24.24.22086",
+              "templateHash": "2744533571013631143"
             }
           },
           "parameters": {
@@ -10421,8 +10439,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "3554907224314175125"
+              "version": "0.24.24.22086",
+              "templateHash": "13099278775051251800"
             },
             "description": "Creates an Azure storage account."
           },
@@ -10646,8 +10664,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "16440196655390446916"
+              "version": "0.24.24.22086",
+              "templateHash": "2184194315885104837"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -10716,8 +10734,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "16440196655390446916"
+              "version": "0.24.24.22086",
+              "templateHash": "2184194315885104837"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -10786,8 +10804,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "16440196655390446916"
+              "version": "0.24.24.22086",
+              "templateHash": "2184194315885104837"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -10856,8 +10874,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "16440196655390446916"
+              "version": "0.24.24.22086",
+              "templateHash": "2184194315885104837"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -10942,8 +10960,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "1703863751305099956"
+              "version": "0.24.24.22086",
+              "templateHash": "4649466732744970707"
             }
           },
           "parameters": {
@@ -11072,6 +11090,10 @@
     "AZURE_COMPUTER_VISION_ENDPOINT": {
       "type": "string",
       "value": "[if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.endpoint.value, '')]"
+    },
+    "AZURE_COMPUTER_VISION_LOCATION": {
+      "type": "string",
+      "value": "[if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.location.value, '')]"
     },
     "AZURE_COMPUTER_VISION_KEY": {
       "type": "string",


### PR DESCRIPTION
- This was causing the deployment to fail when advanced image processing
  was enabled as it overrides the default location in the `main.bicep`
  to `""`
