### PR TITLE
fix: font size changes reverted and removed extra padding

### DIFF
--- a/code/frontend/src/components/Answer/Answer.module.css
+++ b/code/frontend/src/components/Answer/Answer.module.css
@@ -199,7 +199,8 @@ sup {
     }
 }
 
-@media screen and (max-width: 1280px) {
+/* Styles for 1280p resolution at 200% zoom */
+@media screen and (max-width: 640px) {
     .answerContainer, .answerText {
         font-size: 0.6rem !important;
     }

--- a/code/frontend/src/components/Answer/Answer.module.css
+++ b/code/frontend/src/components/Answer/Answer.module.css
@@ -180,11 +180,22 @@ sup {
 
 @media (max-width: 500px) {
     .answerFooter {
-      flex-direction: column; 
+      flex-direction: column;
     }
-  
+
     .citationContainer {
         width: 100%;
         overflow-y: auto;
     }
   }
+
+@media screen and (max-width: 1280px) {
+    .answerContainer, .answerText {
+        font-size: 0.6rem !important;
+    }
+
+    .answerDisclaimer, .accordionTitle, .citationContainer{
+        font-size: 0.5rem !important;
+    }
+
+}

--- a/code/frontend/src/components/Answer/Answer.module.css
+++ b/code/frontend/src/components/Answer/Answer.module.css
@@ -189,6 +189,16 @@ sup {
     }
   }
 
+  /* High contrast mode specific styles */
+  @media screen and (-ms-high-contrast: active), (forced-colors: active) {
+    .answerContainer{
+        border: 2px solid WindowText;
+        padding: 10px;
+        background-color: Window;
+        color: WindowText;
+    }
+}
+
 @media screen and (max-width: 1280px) {
     .answerContainer, .answerText {
         font-size: 0.6rem !important;

--- a/code/frontend/src/pages/chat/Chat.module.css
+++ b/code/frontend/src/pages/chat/Chat.module.css
@@ -326,7 +326,8 @@
     }
 }
 
-@media screen and (max-width: 1280px) {
+/* Styles for 1280p resolution at 200% zoom */
+@media screen and (max-width: 640px) {
     .clearChatBroom {
         left: -23px !important;
     }

--- a/code/frontend/src/pages/chat/Chat.module.css
+++ b/code/frontend/src/pages/chat/Chat.module.css
@@ -311,7 +311,7 @@
 
   /* High contrast mode specific styles */
   @media screen and (-ms-high-contrast: active), (forced-colors: active) {
-    .chatContainer {
+    .chatContainer, .chatMessageUserMessage {
         border: 2px solid WindowText;
         padding: 10px;
         background-color: Window;

--- a/code/frontend/src/pages/chat/Chat.module.css
+++ b/code/frontend/src/pages/chat/Chat.module.css
@@ -317,10 +317,29 @@
         background-color: Window;
         color: WindowText;
     }
+
+    .citationPanel , .citationPanelHeader, .citationPanelTitle, .citationPanelContent{
+        border: 2px solid WindowText;
+        padding: 10px;
+        background-color: Window;
+        color: WindowText;
+    }
 }
 
 @media screen and (max-width: 1280px) {
     .clearChatBroom {
-        left: -17px !important;
+        left: -23px !important;
+    }
+    .citationPanelContent,.chatMessageUserMessage{
+        font-size: 0.6rem !important;
+    }
+    textarea{
+        font-size: 0.6rem !important;
+    }
+    .citationPanelHeader{
+        font-size: 1rem !important;
+    }
+    .citationPanelTitle{
+        font-size: 0.8rem !important;
     }
 }

--- a/code/frontend/src/pages/layout/Layout.module.css
+++ b/code/frontend/src/pages/layout/Layout.module.css
@@ -132,7 +132,8 @@ body {
 
 @media screen and (-ms-high-contrast: active), (forced-colors: active) {
 
-.shareButtonContainer{
+.shareButtonContainer, .headerTitleContainer{
     border: 2px solid WindowText;
 }
+
 }

--- a/code/frontend/src/pages/layout/Layout.module.css
+++ b/code/frontend/src/pages/layout/Layout.module.css
@@ -8,7 +8,6 @@ body {
 .header, .footer {
     width: 100%;
     max-width: 1200px;
-    padding: 1rem;
     box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Purpose
Revert the font size changes and removed extra padding

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
open cwyd chatbot page and check the font size and spacing 

![image](https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/assets/168007985/ec5e2b7c-eef9-45b2-ade3-8acf59ede12e)

