### PR TITLE
fix: Add AI disclaimer to Teams extension

### DIFF
--- a/extensions/teams/cards/cardBuilder.ts
+++ b/extensions/teams/cards/cardBuilder.ts
@@ -59,6 +59,13 @@ export function cardBodyBuilder(citations: any[], assistantAnswer: string): any 
             }, {
                 type: 'ActionSet',
                 actions: []
+            }, {
+                type: CardType.TextBlock,
+                text: "AI-generated content may be incorrect",
+                wrap: true,
+                weight: "lighter",
+                size: "small",
+                color: "default"
             }
         ],
         actions: [],

--- a/extensions/teams/teamsBot.ts
+++ b/extensions/teams/teamsBot.ts
@@ -20,6 +20,7 @@ export class TeamsBot extends TeamsActivityHandler {
     super();
     let newActivity;
     let assistantAnswer = "";
+    let answerwithdisclaimertext = "";
     let activityUpdated = true;
 
     this.onMessage(async (context, next) => {
@@ -117,14 +118,15 @@ export class TeamsBot extends TeamsActivityHandler {
         // Generate the response for the user
         answers.map((answer, index) => {
           if (answer.role === "assistant") {
-            assistantAnswer = answer.content;
+            assistantAnswer = answer.content
+            answerwithdisclaimertext = assistantAnswer + "<div style='color:#707070;font-size:12px;font-family: Segoe UI;font-style: normal;font-weight: 400; line-height: 16px; margin-top: 15px; padding-bottom: 5px;'>AI-generated content may be incorrect</div>" ;
             if (assistantAnswer.startsWith("[doc")) {
               assistantAnswer = EMPTY_RESPONSE;
-              newActivity = MessageFactory.text(assistantAnswer);
+              newActivity = MessageFactory.text(answerwithdisclaimertext);
             } else {
               const citations = parseCitationFromMessage(answers[index - 1]) as Citation[];
               if (citations.length === 0) {
-                newActivity = MessageFactory.text(assistantAnswer);
+                newActivity = MessageFactory.text(answerwithdisclaimertext);
                 newActivity.id = reply.id;
               } else {
                 newActivity = MessageFactory.attachment(cwydResponseBuilder(citations, assistantAnswer));

--- a/extensions/teams/teamsBot.ts
+++ b/extensions/teams/teamsBot.ts
@@ -118,7 +118,7 @@ export class TeamsBot extends TeamsActivityHandler {
         // Generate the response for the user
         answers.map((answer, index) => {
           if (answer.role === "assistant") {
-            assistantAnswer = answer.content
+            assistantAnswer = answer.content;
             answerwithdisclaimertext = assistantAnswer + "<div style='color:#707070;font-size:12px;font-family: Segoe UI;font-style: normal;font-weight: 400; line-height: 16px; margin-top: 15px; padding-bottom: 5px;'>AI-generated content may be incorrect</div>" ;
             if (assistantAnswer.startsWith("[doc")) {
               assistantAnswer = EMPTY_RESPONSE;


### PR DESCRIPTION
## Purpose
The CELA disclaimer for AI generated content that is present in the web app is missing from the Teams version

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No



## How to Test
Go to teams app and ask any question and check whether we are getting disclaimer text along with response.

Please refer the below screenshot:
<img width="920" alt="image" src="https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/assets/169636624/43746543-316b-4fb4-a03b-1e0b3e63a950">

