### PR TITLE
fix: teams bot double encode issue

### DIFF
--- a/extensions/teams/cards/cardBuilder.ts
+++ b/extensions/teams/cards/cardBuilder.ts
@@ -37,7 +37,7 @@ export function actionBuilder(citation: Citation, docId: number): any {
                 {
                     type: CardType.OpenUrl,
                     title: "Go to the source",
-                    url: url,
+                    url: decodeURI(url),
                 }
             ]
         }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* fixes #1104 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
publish the teams bot
```

## What to Check
Verify that the following are valid
* can open a document storage url that contains spaces in the filename

## Other Information
<!-- Add any other helpful information that may be needed here. -->
