### PR TITLE
ci: Enable `report-only-changed-files` in `comment_coverage.yml`

### DIFF
--- a/.github/workflows/comment_coverage.yml
+++ b/.github/workflows/comment_coverage.yml
@@ -44,4 +44,4 @@ jobs:
           pytest-xml-coverage-path: coverage.xml
           junitxml-path: coverage-junit.xml
           issue-number: ${{ github.event.workflow_run.pull_requests[0].number || steps.pr.outputs.result }}
-          report-only-changed-files: ${{ !github.event.workflow_run.head_repository.fork }} # This does not currently work for forks
+          report-only-changed-files: true


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The bug that prevented `report-only-changed-files` working on forks has now been fixed, therefore setting the value to `true`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->
