### PR TITLE
fix: Remove time.sleep from test case

### DIFF
--- a/code/tests/utilities/helpers/test_azure_computer_vision_client.py
+++ b/code/tests/utilities/helpers/test_azure_computer_vision_client.py
@@ -176,22 +176,11 @@ def test_returns_text_vectors(
     assert actual_vectors == expected_vectors
 
 
+@mock.patch("backend.batch.utilities.helpers.azure_computer_vision_client.requests")
 def test_vectorize_image_calls_computer_vision_timeout(
-    httpserver: HTTPServer, azure_computer_vision_client: AzureComputerVisionClient
+        mock_requests: MagicMock, azure_computer_vision_client: AzureComputerVisionClient
 ):
-    # given
-    def handler(_) -> werkzeug.Response:
-        time.sleep(0.3)
-        return werkzeug.Response(
-            json.dumps({"modelVersion": "2022-04-11", "vector": [1.0, 2.0, 3.0]}),
-            status=200,
-        )
-
-    httpserver.expect_request(
-        COMPUTER_VISION_VECTORIZE_IMAGE_PATH,
-        COMPUTER_VISION_VECTORIZE_IMAGE_REQUEST_METHOD,
-    ).respond_with_handler(handler)
-
+    mock_requests.post.side_effect = ReadTimeout("An error occurred")
     # when
     with pytest.raises(Exception) as exec_info:
         azure_computer_vision_client.vectorize_image(IMAGE_URL)


### PR DESCRIPTION
## Purpose
The **test_raises_exception_if_bad_response_code** test in **code/tests/utilities/helpers/test_azure_computer_vision_client.py** fails intermittently. The use of **time.sleep(0.3)** in the previous test, **test_vectorize_image_calls_computer_vision_timeout**, is causing the issue. Therefore, we have updated the test case to remove **time.sleep**, ensuring that all tests now pass consistently.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x ] No

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
Verify **Tests** job (Run Python Tests)
