### PR TITLE
fix: Added title as "Assistant type configuration"

### DIFF
--- a/code/backend/pages/04_Configuration.py
+++ b/code/backend/pages/04_Configuration.py
@@ -208,7 +208,7 @@ try:
     )
     example_user_question_help = "The example user question."
     example_answer_help = "The expected answer."
-    with st.expander("", expanded=True):
+    with st.expander("Assistant type configuration", expanded=True):
         cols = st.columns([2, 4])
         with cols[0]:
             st.selectbox(


### PR DESCRIPTION
## Purpose
Assisant type section title under Configuration on admin page not visible when collapsed
* ...

## Does this introduce a breaking change?
Added tittle as "Assistent type configuration"

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
Jump over configuration section and try to expand and collapse the "Assistant Type" section 
Expected result: Title "Assistant type configuration " should be visible when collapsed.

![image](https://github.com/user-attachments/assets/5c937930-8f23-40fd-b1ca-ae146668050d)
