### PR TITLE
fix: Disable send button until speech recording stopped

### DIFF
--- a/code/frontend/src/components/QuestionInput/QuestionInput.module.css
+++ b/code/frontend/src/components/QuestionInput/QuestionInput.module.css
@@ -35,6 +35,13 @@
     height: 23px;
 }
 
+.SendButtonDisabled{
+    pointer-events: none;
+    width: 24px;
+    height: 23px;
+    margin-right: 12px;
+}
+
 .questionInputSendButtonDisabled {
     /* opacity: 0.4; */
     width: 24px;
@@ -60,6 +67,10 @@
     height: 30px;
 }
 
+.microphoneIcon ,.microphoneIconActive{
+    height: 1.3em;
+}
+
 .questionInputMicrophone {
     width: 24px;
     height: 24px;
@@ -70,8 +81,11 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-right: 12px;
-    margin-top: 25px;
+    margin-right: 1rem;
+    margin-top: 0.3rem;
+    width: 3%;
+    min-width: 3%;
+    height: 70px;
   }
 
 

--- a/code/frontend/src/components/QuestionInput/QuestionInput.tsx
+++ b/code/frontend/src/components/QuestionInput/QuestionInput.tsx
@@ -11,6 +11,7 @@ interface Props {
   onMicrophoneClick: () => void;
   onStopClick: () => void;
   disabled: boolean;
+  isSendButtonDisabled:boolean;
   placeholder?: string;
   clearOnSend?: boolean;
   recognizedText: string;
@@ -24,6 +25,7 @@ export const QuestionInput = ({
   onMicrophoneClick,
   onStopClick,
   disabled,
+  isSendButtonDisabled,
   placeholder,
   clearOnSend,
   recognizedText,
@@ -131,26 +133,28 @@ export const QuestionInput = ({
         </div>
 
         {/* Send Button */}
-        <div
-          role="button"
-          tabIndex={0}
-          aria-label="Ask question button"
-          onClick={sendQuestion}
-          onKeyDown={(e) =>
-            e.key === "Enter" || e.key === " " ? sendQuestion() : null
-          }
-          className={styles.questionInputSendButtonContainer}
-        >
-          {disabled ? (
-            <SendRegular className={styles.questionInputSendButtonDisabled} />
-          ) : (
-            <img
-              src={Send}
-              className={styles.questionInputSendButton}
-              alt="Send"
-            />
-          )}
-        </div>
+        {isSendButtonDisabled?( <SendRegular className={styles.SendButtonDisabled} />):(
+              <div
+              role="button"
+              tabIndex={0}
+              aria-label="Ask question button"
+              onClick={sendQuestion}
+              onKeyDown={(e) =>
+                e.key === "Enter" || e.key === " " ? sendQuestion() : null
+              }
+              className={styles.questionInputSendButtonContainer}
+              >
+              {disabled? (
+                <SendRegular className={styles.questionInputSendButtonDisabled} />
+              ) : (
+                <img
+                  src={Send}
+                  className={styles.questionInputSendButton}
+                  alt="Send"
+                />
+              )}
+              </div>
+        )}
       </div>
     </Stack>
   );

--- a/code/frontend/src/pages/chat/Chat.tsx
+++ b/code/frontend/src/pages/chat/Chat.tsx
@@ -34,6 +34,8 @@ const Chat = () => {
   const chatMessageStreamEnd = useRef<HTMLDivElement | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [showLoadingMessage, setShowLoadingMessage] = useState<boolean>(false);
+
+  const [isSendButtonDisabled, setSendButtonDisabled] = useState(false);
   const [activeCitation, setActiveCitation] =
     useState<
       [
@@ -180,16 +182,16 @@ const Chat = () => {
       }
       setIsRecognizing(false);
       setRecognizedText("");
+      setSendButtonDisabled(false);
       setIsListening(false);
     }
   };
 
   const onMicrophoneClick = async () => {
     if (!isRecognizing) {
-      // console.log("Starting speech recognition...");
+      setSendButtonDisabled(true);
       await startSpeechRecognition();
     } else {
-      // console.log("Stopping speech recognition...");
       stopSpeechRecognition();
       setRecognizedText(userMessage);
     }
@@ -355,6 +357,7 @@ const Chat = () => {
               disabled={isLoading}
               onSend={(question) => makeApiRequest(question)}
               recognizedText={recognizedText}
+              isSendButtonDisabled={isSendButtonDisabled}
               onMicrophoneClick={onMicrophoneClick}
               onStopClick={stopSpeechRecognition}
               isListening={isListening}


### PR DESCRIPTION
## Purpose
mic recording and send button functionality not in sync

## Does this introduce a breaking change?
Overlapping of "Listening.." and "Stop Generating" messages
After recording query when we send the it,  "Listening.." and "Stop Generating" are overlapping 

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
once clicked on send button 
microphone recording should be stopped 
Overlapping of "Listening.." and "Stop Generating" messages
After recording query when we send the it,  "Listening.." and "Stop Generating" are overlapping 

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

## What to Check
1. click on mic to start the recording 
2. once we click on send button the recorded sentence is sent, but mice don't stop recording
3. if user keeps talking boat concatenate the first said sentence and currently speaking statement and combinedly provides the result. 

![image](https://github.com/user-attachments/assets/534b0fd0-08fb-4e22-a854-eb48d5aaaf4d)

![image](https://github.com/user-attachments/assets/1cc8355c-8e47-4d4d-8d75-762ae3b2e356)


