### PR TITLE
fix: AZURE_SEARCH_TOP_K and AZURE_OPENAI_SYSTEM_MESSAGE keeps reseting after running azd env set and azd up command

### DIFF
--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -39,6 +39,8 @@ param azureOpenAIMaxTokens = readEnvironmentVariable('AZURE_OPENAI_MAX_TOKENS', 
 param azureOpenAITemperature = readEnvironmentVariable('AZURE_OPENAI_TEMPERATURE', '0')
 param azureOpenAITopP = readEnvironmentVariable('AZURE_OPENAI_TOP_P', '1')
 param azureOpenAIStopSequence = readEnvironmentVariable('AZURE_OPENAI_STOP_SEQUENCE', '\n')
+param azureOpenAISystemMessage = readEnvironmentVariable('AZURE_OPENAI_SYSTEM_MESSAGE', 'You are an AI assistant that helps people find information.')
+param azureSearchTopK = readEnvironmentVariable('AZURE_SEARCH_TOP_K', '5')
 
 // Computer Vision parameters
 param computerVisionLocation = readEnvironmentVariable('AZURE_COMPUTER_VISION_LOCATION', '')


### PR DESCRIPTION
## Purpose
 Added azureOpenAISystemMessage and azureSearchTopK param in main.bicepparam file to set the value of AZURE_SEARCH_TOP_K and AZURE_OPENAI_SYSTEM_MESSAGE env variable in azure using azd env set and azd up command

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

## What to Check
Run below commands from VS code powershell terminal:

azd env set AZURE_SEARCH_TOP_K 15 
azd up
azd env refresh

And check whether value of AZURE_SEARCH_TOP_K is getting updated in azure and local both. And the value should not get reset to 5 in .env file in your local.

Please find below screenshot for your reference:

<img width="588" alt="image" src="https://github.com/user-attachments/assets/726152ee-3efc-4bb1-b1c2-a5a47e072035">


