### PR TITLE
fix: Type JPG upload issue fix on explore page under admin

### DIFF
--- a/code/backend/batch/utilities/helpers/config/default.json
+++ b/code/backend/batch/utilities/helpers/config/default.json
@@ -97,6 +97,17 @@
       }
     },
     {
+      "document_type": "jpeg",
+      "chunking": {
+        "strategy": "layout",
+        "size": 500,
+        "overlap": 100
+      },
+      "loading": {
+        "strategy": "layout"
+      }
+    },
+    {
       "document_type": "png",
       "chunking": {
         "strategy": "layout",


### PR DESCRIPTION
Bug:  5527 

## Purpose
it is for uploading JPEG file and in explore dropdown jpeg history also should be visible

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
Deploy CWYD 
On Admin page under ingest data upload .PNG file
Under Explore data section's "Explore data' dropdown check if that uploaded file is visible or not 
.PNG is visible when I checked.
Then upload .JPEG file and check under "Explore data" dropdown, if it's visible or not
for me it is not visible 
Image
Repeat step number 5 for .MD files
Image  
getting same result, not visible 
Image

git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```
![image](https://github.com/user-attachments/assets/3989d51a-ac3a-48da-8503-53a543e121f5)

