### PR TITLE
fix: Configuration tab "Reset configuration to Defaults" confuses the user whether it is button or dropdown.

### DIFF
--- a/code/backend/pages/04_Configuration.py
+++ b/code/backend/pages/04_Configuration.py
@@ -8,6 +8,7 @@ from batch.utilities.helpers.env_helper import EnvHelper
 from batch.utilities.helpers.config.config_helper import ConfigHelper
 from azure.core.exceptions import ResourceNotFoundError
 from batch.utilities.helpers.config.assistant_strategy import AssistantStrategy
+
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 env_helper: EnvHelper = EnvHelper()
 
@@ -95,10 +96,14 @@ def validate_answering_user_prompt():
 def config_legal_assistant_prompt():
     if st.session_state["ai_assistant_type"] == AssistantStrategy.LEGAL_ASSISTANT.value:
         st.success("Legal Assistant Prompt")
-        st.session_state["answering_user_prompt"] = ConfigHelper.get_default_legal_assistant()
+        st.session_state["answering_user_prompt"] = (
+            ConfigHelper.get_default_legal_assistant()
+        )
     else:
         st.success("Default Assistant Prompt")
-        st.session_state["answering_user_prompt"] = ConfigHelper.get_default_assistant_prompt()
+        st.session_state["answering_user_prompt"] = (
+            ConfigHelper.get_default_assistant_prompt()
+        )
 
 
 def validate_post_answering_prompt():
@@ -374,7 +379,7 @@ try:
                     "enable_post_answering_prompt"
                 ],
                 "enable_content_safety": st.session_state["enable_content_safety"],
-                "ai_assistant_type": st.session_state["ai_assistant_type"]
+                "ai_assistant_type": st.session_state["ai_assistant_type"],
             },
             "messages": {
                 "post_answering_filter": st.session_state[
@@ -404,9 +409,16 @@ try:
         )
 
     with st.popover(":red[Reset configuration to defaults]"):
+
+        # Close button with a custom class
+        if st.button("X", key="close_popup", help="Close popup"):
+            st.session_state["popup_open"] = False
+            st.rerun()
+
         st.write(
             "**Resetting the configuration cannot be reversed, proceed with caution!**"
         )
+
         st.text_input('Enter "reset" to proceed', key="reset_configuration")
         if st.button(
             ":red[Reset]", disabled=st.session_state["reset_configuration"] != "reset"

--- a/code/backend/pages/common.css
+++ b/code/backend/pages/common.css
@@ -1,8 +1,8 @@
 #MainMenu {visibility: hidden;}
 footer {visibility: hidden;}
 header {visibility: hidden;}
-.st-emotion-cache-1kyxreq{width:100%}
-
+[data-testid="baseButton-secondary"] svg{display: none;}
+[data-testid="stPopoverBody"] button{float: right;}
 .stTextArea{width: 100% !important;}
 @media screen and (-ms-high-contrast: active), (forced-colors: active) {
     section, .st-emotion-cache-ch5dnh{

--- a/code/backend/pages/common.css
+++ b/code/backend/pages/common.css
@@ -3,6 +3,19 @@ footer {visibility: hidden;}
 header {visibility: hidden;}
 [data-testid="baseButton-secondary"] svg{display: none;}
 [data-testid="stPopoverBody"] button{float: right;}
+[data-testid="stPopoverBody"] .stTooltipIcon {
+    position: absolute;
+    right: 0;
+    margin-top: 0.3rem;
+}
+[data-testid="stPopoverBody"] [data-testid="stVerticalBlock"]{
+    width: 520px;
+}
+[data-testid="stPopoverBody"] .stTooltipIcon [data-testid="baseButton-secondary"]{
+    border: none;
+    z-index: 1;
+}
+
 .stTextArea{width: 100% !important;}
 @media screen and (-ms-high-contrast: active), (forced-colors: active) {
     section, .st-emotion-cache-ch5dnh{

--- a/code/backend/pages/common.css
+++ b/code/backend/pages/common.css
@@ -3,6 +3,10 @@ footer {visibility: hidden;}
 header {visibility: hidden;}
 [data-testid="baseButton-secondary"] svg{display: none;}
 [data-testid="stPopoverBody"] button{float: right;}
+[data-testid="stSidebar"] {z-index: 999;}
+[data-testid="stPopoverBody"] .stTooltipIcon [data-testid="baseButton-secondary"] p{
+    font-weight: bold;
+}
 [data-testid="stPopoverBody"] .stTooltipIcon {
     position: absolute;
     right: 0;


### PR DESCRIPTION
## Purpose
Configuration tab "Reset configuration to Defaults" confuses the user whether it is button or dropdown. and adding x button for close the popup

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install


## What to Check
1. go to the Admin page, Scroll down under "Configuration" section
2. Click on "Reset to default configuration" tab 
3. the up arrow indicates the tab as dropdown, but it pops up this window. 
4. It creates confusion whether it is dropdown or button. 

![image](https://github.com/user-attachments/assets/c9a8abaf-02a6-4f2c-822b-e0aff8d486e5)
