### PR TITLE
fix: Updated the column name as "id" for the azureSearchFieldId column in main.json file

### DIFF
--- a/infra/main.json
+++ b/infra/main.json
@@ -136,7 +136,7 @@
     },
     "azureSearchFieldId": {
       "type": "string",
-      "defaultValue": "Id",
+      "defaultValue": "id",
       "metadata": {
         "description": "Id columns"
       }


### PR DESCRIPTION
## Purpose

* Updated the column name as "id" for the azureSearchFieldId column in main.json file

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```


## What to Check
Check whether the value of AZURE_SEARCH_FIELDS_ID variable got updated to "id" in search index after doing the deployment. Please find below screenshot for your reference:

<img width="911" alt="image" src="https://github.com/user-attachments/assets/f7648c65-bdef-49a4-8bf9-50411237021c">



