### PR TITLE
refactor: Stop generating requirements.txt during deployment

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -29,24 +29,8 @@ services:
     project: ./code/backend
     language: py
     host: appservice
-    hooks:
-      prepackage:
-        windows:
-          shell: pwsh
-          run: poetry install; poetry export -o requirements.txt
-        posix:
-          shell: sh
-          run: poetry install; poetry export -o requirements.txt
 
   function:
     project: ./code/backend/batch
     language: py
     host: function
-    hooks:
-      prepackage:
-        windows:
-          shell: pwsh
-          run: poetry install; poetry export -o requirements.txt
-        posix:
-          shell: sh
-          run: poetry install; poetry export -o requirements.txt

--- a/scripts/package_frontend.ps1
+++ b/scripts/package_frontend.ps1
@@ -3,9 +3,10 @@ rm dist/* -r -Force
 
 # Python
 poetry install
-poetry export -o dist/requirements.txt
 cp *.py dist -Force
 cp backend dist -r -Force
+cp ../pyproject.toml dist -Force
+cp ../poetry.lock dist -Force
 
 # Node
 cd frontend

--- a/scripts/package_frontend.sh
+++ b/scripts/package_frontend.sh
@@ -4,9 +4,10 @@ set -eou pipefail
 mkdir -p dist
 rm -rf dist/*
 poetry install
-poetry export -o dist/requirements.txt
 cp *.py dist
 cp -r backend dist
+cp ../pyproject.toml dist
+cp ../poetry.lock dist
 
 cd frontend
 npm install


### PR DESCRIPTION
Azure App Service now supports poetry directly so this is no longer needed
