### PR TITLE
feat: Implemented functionality to enable multilingual filename uploads in the Admin App.

### DIFF
--- a/code/backend/pages/01_Ingest_Data.py
+++ b/code/backend/pages/01_Ingest_Data.py
@@ -1,4 +1,5 @@
 from os import path
+import re
 import streamlit as st
 import traceback
 import requests
@@ -56,6 +57,11 @@ def add_urls():
     add_url_embeddings(urls)
 
 
+def sanitize_metadata_value(value):
+    # Remove invalid characters
+    return re.sub(r"[^a-zA-Z0-9-_ .]", "?", value)
+
+
 def add_url_embeddings(urls: list[str]):
     params = {}
     if env_helper.FUNCTION_KEY is not None:
@@ -89,7 +95,7 @@ try:
             for up in uploaded_files:
                 # To read file as bytes:
                 bytes_data = up.getvalue()
-                title = up.name.encode("latin-1", "replace").decode("latin-1")
+                title = sanitize_metadata_value(up.name)
                 if st.session_state.get("filename", "") != up.name:
                     # Upload a new file
                     st.session_state["filename"] = up.name


### PR DESCRIPTION


## Purpose
* Enable the users to upload files with multilingual filenames in the Admin App for improved accessibility

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No



## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```
**Before Fix:**

<img width="941" alt="image" src="https://github.com/user-attachments/assets/253f6db4-c815-4563-9a35-2f9b04cf9dd5">


**After Fix:**

<img width="950" alt="UserStory-8807" src="https://github.com/user-attachments/assets/dc4ca812-b8a3-4023-88cd-b26df1302bc7">
<img width="944" alt="UserStory-8807-1" src="https://github.com/user-attachments/assets/c38ae70d-fef7-4637-b8f9-fa552008f4cd">


## What to Check

* Upload files with filenames in English, Italian, French, German, etc., and verify whether the files are uploading successfully.
