### PR TITLE
fix: Fix for Chat history thread title is saved with space

### DIFF
--- a/code/backend/api/chat_history.py
+++ b/code/backend/api/chat_history.py
@@ -143,8 +143,8 @@ async def rename_conversation():
 
         # update the title
         title = request_json.get("title", None)
-        if not title:
-            return (jsonify({"error": "title is required"}), 400)
+        if not title or title.strip() == "":
+            return jsonify({"error": "title is required"}), 400
         conversation["title"] = title
         updated_conversation = await cosmos_conversation_client.upsert_conversation(
             conversation
@@ -321,7 +321,10 @@ async def delete_all_conversations():
 
     except Exception as e:
         logger.exception("Exception in /delete" + str(e))
-        return (jsonify({"error": "Error while deleting all history conversation"}), 500)
+        return (
+            jsonify({"error": "Error while deleting all history conversation"}),
+            500,
+        )
 
 
 @bp_chat_history_response.route("/history/update", methods=["POST"])

--- a/code/frontend/src/pages/chat/ChatHistoryListItem.tsx
+++ b/code/frontend/src/pages/chat/ChatHistoryListItem.tsx
@@ -126,7 +126,7 @@ export const ChatHistoryListItemCell: React.FC<
 
   const handleSaveEdit = async (e: any) => {
     e.preventDefault();
-    if (errorRename || renameLoading) {
+    if (errorRename || renameLoading || _.trim(editTitle) === "") {
       return;
     }
 
@@ -219,7 +219,7 @@ export const ChatHistoryListItemCell: React.FC<
                     disabled={errorRename ? true : false}
                   />
                 </Stack.Item>
-                {editTitle && (
+                {_.trim(editTitle) && (
                   <Stack.Item>
                     <Stack
                       aria-label="action button group"


### PR DESCRIPTION
## Purpose
Fix for Chat history thread title is saved with space

[Bug 9546](https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/9546): [QA] - CWYD - Chat history thread title is saved with space

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

## What to Check
Deploy CWYD with GPT 4o 
Go to CWYD Admin and enable chat history if not enabled
Go to CWYD web url and save chat history conversations
Click on Show chat history button and click on Edit icon for a chat thread
Remove the text in chat thread title and update with 1 empty space
Click on Tick icon
Expected behavior:  Chat thread title should not be saved with empty space
Actual behavior: Chat thread title saved with empty space
