### PR TITLE
fix: Use new docker syntax for ENV

### DIFF
--- a/docker/Admin.Dockerfile
+++ b/docker/Admin.Dockerfile
@@ -7,6 +7,6 @@ RUN pip install --upgrade pip && pip install poetry && poetry export -o requirem
 COPY ./code/backend /usr/local/src/myscripts/admin
 COPY ./code/backend/batch/utilities /usr/local/src/myscripts/utilities
 WORKDIR /usr/local/src/myscripts/admin
-ENV PYTHONPATH "${PYTHONPATH}:/usr/local/src/myscripts/"
+ENV PYTHONPATH="${PYTHONPATH}:/usr/local/src/myscripts/"
 EXPOSE 80
 CMD ["streamlit", "run", "Admin.py", "--server.port", "80", "--server.enableXsrfProtection", "false"]

--- a/docker/Admin.Dockerfile
+++ b/docker/Admin.Dockerfile
@@ -7,6 +7,6 @@ RUN pip install --upgrade pip && pip install poetry && poetry export -o requirem
 COPY ./code/backend /usr/local/src/myscripts/admin
 COPY ./code/backend/batch/utilities /usr/local/src/myscripts/utilities
 WORKDIR /usr/local/src/myscripts/admin
-ENV PYTHONPATH="${PYTHONPATH}:/usr/local/src/myscripts/"
+ENV PYTHONPATH="${PYTHONPATH-''}:/usr/local/src/myscripts/"
 EXPOSE 80
 CMD ["streamlit", "run", "Admin.py", "--server.port", "80", "--server.enableXsrfProtection", "false"]

--- a/docker/Admin.Dockerfile
+++ b/docker/Admin.Dockerfile
@@ -7,6 +7,7 @@ RUN pip install --upgrade pip && pip install poetry && poetry export -o requirem
 COPY ./code/backend /usr/local/src/myscripts/admin
 COPY ./code/backend/batch/utilities /usr/local/src/myscripts/utilities
 WORKDIR /usr/local/src/myscripts/admin
-ENV PYTHONPATH="${PYTHONPATH:-}:/usr/local/src/myscripts/"
+# https://github.com/docker/buildx/issues/2751
+ENV PYTHONPATH="${PYTHONPATH}:/usr/local/src/myscripts/"
 EXPOSE 80
 CMD ["streamlit", "run", "Admin.py", "--server.port", "80", "--server.enableXsrfProtection", "false"]

--- a/docker/Admin.Dockerfile
+++ b/docker/Admin.Dockerfile
@@ -7,6 +7,6 @@ RUN pip install --upgrade pip && pip install poetry && poetry export -o requirem
 COPY ./code/backend /usr/local/src/myscripts/admin
 COPY ./code/backend/batch/utilities /usr/local/src/myscripts/utilities
 WORKDIR /usr/local/src/myscripts/admin
-ENV PYTHONPATH="${PYTHONPATH-''}:/usr/local/src/myscripts/"
+ENV PYTHONPATH="${PYTHONPATH:-}:/usr/local/src/myscripts/"
 EXPOSE 80
 CMD ["streamlit", "run", "Admin.py", "--server.port", "80", "--server.enableXsrfProtection", "false"]

--- a/docker/Frontend.Dockerfile
+++ b/docker/Frontend.Dockerfile
@@ -19,6 +19,6 @@ RUN pip install --upgrade pip && pip install poetry uwsgi && poetry export -o re
 COPY ./code/*.py /usr/src/app/
 COPY ./code/backend /usr/src/app/backend
 COPY --from=frontend /home/node/app/dist/static /usr/src/app/static/
-ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app"
+ENV PYTHONPATH="${PYTHONPATH}:/usr/src/app"
 EXPOSE 80
 CMD ["uwsgi", "--http", ":80", "--wsgi-file", "app.py", "--callable", "app", "-b", "32768", "--http-timeout", "230"]

--- a/docker/Frontend.Dockerfile
+++ b/docker/Frontend.Dockerfile
@@ -19,6 +19,7 @@ RUN pip install --upgrade pip && pip install poetry uwsgi && poetry export -o re
 COPY ./code/*.py /usr/src/app/
 COPY ./code/backend /usr/src/app/backend
 COPY --from=frontend /home/node/app/dist/static /usr/src/app/static/
-ENV PYTHONPATH="${PYTHONPATH:-}:/usr/src/app"
+# https://github.com/docker/buildx/issues/2751
+ENV PYTHONPATH="${PYTHONPATH}:/usr/src/app"
 EXPOSE 80
 CMD ["uwsgi", "--http", ":80", "--wsgi-file", "app.py", "--callable", "app", "-b", "32768", "--http-timeout", "230"]

--- a/docker/Frontend.Dockerfile
+++ b/docker/Frontend.Dockerfile
@@ -19,6 +19,6 @@ RUN pip install --upgrade pip && pip install poetry uwsgi && poetry export -o re
 COPY ./code/*.py /usr/src/app/
 COPY ./code/backend /usr/src/app/backend
 COPY --from=frontend /home/node/app/dist/static /usr/src/app/static/
-ENV PYTHONPATH="${PYTHONPATH-''}:/usr/src/app"
+ENV PYTHONPATH="${PYTHONPATH:-}:/usr/src/app"
 EXPOSE 80
 CMD ["uwsgi", "--http", ":80", "--wsgi-file", "app.py", "--callable", "app", "-b", "32768", "--http-timeout", "230"]

--- a/docker/Frontend.Dockerfile
+++ b/docker/Frontend.Dockerfile
@@ -19,6 +19,6 @@ RUN pip install --upgrade pip && pip install poetry uwsgi && poetry export -o re
 COPY ./code/*.py /usr/src/app/
 COPY ./code/backend /usr/src/app/backend
 COPY --from=frontend /home/node/app/dist/static /usr/src/app/static/
-ENV PYTHONPATH="${PYTHONPATH}:/usr/src/app"
+ENV PYTHONPATH="${PYTHONPATH-''}:/usr/src/app"
 EXPOSE 80
 CMD ["uwsgi", "--http", ":80", "--wsgi-file", "app.py", "--callable", "app", "-b", "32768", "--http-timeout", "230"]


### PR DESCRIPTION
## Purpose
Fixes #1464 

Use new docker syntax for ENV in Dockerfiles `ENV key=value`

We cannot exclude the append behaviour of PYTHONPATH for the moment as there is no ignore-rule
See [https://github.com/docker/buildx/issues/2751](https://github.com/docker/buildx/issues/2751)

In our case PYTHONPATH is actually blank in both cases - but it is legitimate pattern to append to the PYTHONPATH in case the base image adds at a later date.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
CI will build without any warnings
