### PR TITLE
fix: Warning message displayed twice in chat history update

### DIFF
--- a/code/frontend/src/pages/chat/ChatHistoryListItem.tsx
+++ b/code/frontend/src/pages/chat/ChatHistoryListItem.tsx
@@ -215,7 +215,7 @@ export const ChatHistoryListItemCell: React.FC<
                     placeholder={item.title}
                     onChange={chatHistoryTitleOnChange}
                     onKeyDown={handleKeyPressEdit}
-                    errorMessage={errorRename}
+                    // errorMessage={errorRename}
                     disabled={errorRename ? true : false}
                   />
                 </Stack.Item>


### PR DESCRIPTION
## Purpose
Fixed issue with duplicate warning messages in chat history update

[Bug 9545](https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/9545): [QA] - CWYD - Warning message displayed twice in chat history update

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

## What to Check
Deploy CWYD with GPT 4o
Go to CWYD Admin and enable chat history if not enabled
Go to CWYD web url and save chat history conversations
Click on Show chat history button and click on Edit icon for a chat thread
Disconnect from network
Update the text in chat thread title and click on Tick icon
Observe the warning message
The warning message "Error: could not rename file" should be displayed only once.
