### PR TITLE
Fix: Updated reset configuration to use dialog instead of popover which now closes on X button click, Submit Button Now Resets Widgets to default values by clearing config.

### DIFF
--- a/code/backend/pages/04_Configuration.py
+++ b/code/backend/pages/04_Configuration.py
@@ -491,37 +491,43 @@ Use the Retrieved Documents to answer the question: {question}
                     "Configuration saved successfully! Please restart the chat service for these changes to take effect."
                 )
 
-    with st.popover(":red[Reset configuration to defaults]"):
-
-        # Close button with a custom class
-        if st.button("X", key="close_popup", help="Close popup"):
-            st.session_state["popup_open"] = False
-            st.rerun()
-
-        st.write(
-            "**Resetting the configuration cannot be reversed, proceed with caution!**"
-        )
+    @st.dialog("Reset Configuration", width="small")
+    def reset_config_dialog():
+        st.write("**Resetting the configuration cannot be reversed. Proceed with caution!**")
 
         st.text_input('Enter "reset" to proceed', key="reset_configuration")
         if st.button(
-            ":red[Reset]", disabled=st.session_state["reset_configuration"] != "reset"
+            ":red[Reset Now]",
+            disabled=st.session_state.get("reset_configuration", "") != "reset",
+            key="confirm_reset"
         ):
-            try:
-                ConfigHelper.delete_config()
-            except ResourceNotFoundError:
-                pass
+            with st.spinner("Resetting Configuration to Default values..."):
+                try:
+                    ConfigHelper.delete_config()
+                except ResourceNotFoundError:
+                    pass
 
-            for key in st.session_state:
-                del st.session_state[key]
-
+                ConfigHelper.clear_config()
+            st.session_state.clear()
             st.session_state["reset"] = True
             st.session_state["reset_configuration"] = ""
+            st.session_state["show_reset_dialog"] = False
             st.rerun()
 
-        if st.session_state.get("reset") is True:
-            st.success("Configuration reset successfully!")
-            del st.session_state["reset"]
-            del st.session_state["reset_configuration"]
+    # Reset configuration button
+    if st.button(":red[Reset configuration to defaults]"):
+        st.session_state["show_reset_dialog"] = True
+
+    # Open the dialog if needed
+    if st.session_state.get("show_reset_dialog"):
+        reset_config_dialog()
+        st.session_state["show_reset_dialog"] = False
+
+    # After reset success
+    if st.session_state.get("reset"):
+        st.success("Configuration reset successfully!")
+        del st.session_state["reset"]
+        del st.session_state["reset_configuration"]
 
 except Exception as e:
     logger.error(f"Error occurred: {e}")


### PR DESCRIPTION
Updated reset configuration to use dialog instead of popover which now closes on X button click, Submit Button Now Resets Widgets to default values by clearing config.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No
This pull request refactors the reset configuration functionality in `04_Configuration.py` to improve user experience and code readability. The main change replaces the previous popover-based implementation with a dialog-based approach using `st.dialog`. Additional adjustments streamline the reset process and enhance session state handling.

### Refactoring and User Experience Improvements:

* Replaced the popover-based reset configuration UI with a dialog-based implementation using `st.dialog`, providing a more intuitive and consistent user interface for resetting configurations.
* Improved session state handling by introducing a `show_reset_dialog` flag to control dialog visibility and clearing session state more effectively after a reset.
* Enhanced button labeling for clarity, changing "Reset" to "Reset Now" to better convey the action's immediacy.

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
This pull request refactors the reset configuration functionality in `04_Configuration.py` to improve user experience and code maintainability. The changes replace the previous `popover` implementation with a dialog-based approach, streamline session state management, and enhance the reset confirmation process.

### Refactoring of reset configuration functionality:

* Replaced the `st.popover` implementation with an `@st.dialog` decorator for better UI consistency and clarity. The new dialog includes a confirmation input and reset button labeled `:red[Reset Now]`.
* Simplified session state management by using `st.session_state.clear()` to reset all session keys and ensuring proper handling of dialog visibility with the `show_reset_dialog` state variable.
* Improved reset confirmation by requiring users to type "reset" in a text input before enabling the reset button, reducing the risk of accidental resets.