### PR TITLE
fix: Changed the button label from "Reset Now" to "Reset"

### DIFF
--- a/code/backend/pages/04_Configuration.py
+++ b/code/backend/pages/04_Configuration.py
@@ -497,7 +497,7 @@ Use the Retrieved Documents to answer the question: {question}
 
         st.text_input('Enter "reset" to proceed', key="reset_configuration")
         if st.button(
-            ":red[Reset Now]",
+            ":red[Reset]",
             disabled=st.session_state.get("reset_configuration", "") != "reset",
             key="confirm_reset"
         ):


### PR DESCRIPTION
This pull request includes a minor update to the `reset_config_dialog` function in `code/backend/pages/04_Configuration.py`. The change modifies the text of a button to improve clarity.

* Updated the button label from `":red[Reset Now]"` to `":red[Reset]"` to simplify the wording in the `reset_config_dialog` function.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No