### PR TITLE
chore: added github workflow to group dependabot security updates

### DIFF
--- a/.github/workflows/group_dependabot_security_updates.yml
+++ b/.github/workflows/group_dependabot_security_updates.yml
@@ -36,6 +36,11 @@ on:
         description: "Group name for yarn ecosystem"
         required: false
         default: "frontend"
+      dry_run:
+        description: "Run in dry-run mode (no changes will be pushed or PRs created/closed)"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   group-dependabot-prs:
@@ -46,7 +51,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TARGET_BRANCH: "main"
-      DRY_RUN: "false"
+      DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
       GROUP_CONFIG_PIP: ${{ github.event.inputs.group_config_pip || 'backend' }}
       GROUP_CONFIG_NPM: ${{ github.event.inputs.group_config_npm || 'frontend' }}
       GROUP_CONFIG_YARN: ${{ github.event.inputs.group_config_yarn || 'frontend' }}
@@ -139,7 +144,9 @@ jobs:
 
           for file in "${grouped_files[@]}"; do
             group_name=$(basename "$file" .txt)
-            branch_name="actions/grouped-${group_name}-updates"
+            # Sanitize group_name: allow only alphanum, dash, underscore
+            safe_group_name=$(echo "$group_name" | tr -c '[:alnum:]_-' '-')
+            branch_name="security/grouped-${safe_group_name}-updates"
             git checkout -B "$branch_name"
 
             while read -r number ref group; do


### PR DESCRIPTION
## Purpose
This workflow automates the creation of grouped pull requests for Dependabot security updates, streamlining vulnerability patching across dependencies while excluding GitHub Action updates to maintain manual oversight of CI/CD pipeline changes. It enhances update efficiency, reduces PR noise, and supports secure dependency management.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
