### PR TITLE
fix: Remove Exposed Speech Service API Key from Network Calls

### DIFF
--- a/code/create_app.py
+++ b/code/create_app.py
@@ -526,7 +526,6 @@ def create_app():
             if response.status_code == 200:
                 return {
                     "token": response.text,
-                    "key": speech_key,
                     "region": env_helper.AZURE_SPEECH_SERVICE_REGION,
                     "languages": env_helper.AZURE_SPEECH_RECOGNIZER_LANGUAGES,
                 }

--- a/code/frontend/src/components/Answer/Answer.test.tsx
+++ b/code/frontend/src/components/Answer/Answer.test.tsx
@@ -13,7 +13,7 @@ import { conversationResponseWithCitations } from "../../../__mocks__/SampleData
 jest.mock('microsoft-cognitiveservices-speech-sdk', () => {
   return {
     SpeechConfig: {
-      fromSubscription: jest.fn(),
+      fromAuthorizationToken: jest.fn(),
     },
     AudioConfig: {
       fromDefaultSpeakerOutput: jest.fn(),
@@ -51,7 +51,7 @@ const speechMockData = {
 jest.mock("microsoft-cognitiveservices-speech-sdk", () => {
   return {
     SpeechConfig: {
-      fromSubscription: jest.fn(),
+      fromAuthorizationToken: jest.fn(),
       fromSpeakerOutput: jest.fn().mockReturnValue({}),
     },
     AudioConfig: {

--- a/code/frontend/src/components/Answer/Answer.tsx
+++ b/code/frontend/src/components/Answer/Answer.tsx
@@ -51,7 +51,7 @@ export const Answer = ({
   const [audioContext, setAudioContext] = useState<AudioContext | null>(null); //Manully  manage the audio context eg pausing resuming
 
   const [synthesizerData, setSynthesizerData] = useState({
-    key: "",
+    token: "",
     region: "",
   });
   const [synthesizer, setSynthesizer] =
@@ -70,8 +70,8 @@ export const Answer = ({
   };
 
   const initializeSynthesizer = () => {
-    const speechConfig = sdk.SpeechConfig.fromSubscription(
-      synthesizerData.key,
+    const speechConfig = sdk.SpeechConfig.fromAuthorizationToken(
+      synthesizerData.token,
       synthesizerData.region
     );
     const newAudioDestination = new SpeechSDK.SpeakerAudioDestination();
@@ -90,7 +90,7 @@ export const Answer = ({
   };
 
   useEffect(() => {
-    if (synthesizerData.key != "") {
+    if (synthesizerData.token != "") {
       initializeSynthesizer();
 
       return () => {
@@ -112,12 +112,12 @@ export const Answer = ({
       const response = await fetch("/api/speech");
       try {
         if (!response.ok) {
-         throw new Error("Network response was not ok");
+          throw new Error("Network response was not ok");
         }
-      const data = await response.json();
-      setSynthesizerData({ key: data.key, region: data.region });
-      } catch(e) {
-        console.log(e)
+        const data = await response.json();
+        setSynthesizerData({ token: data.token, region: data.region });
+      } catch (e) {
+        console.log(e);
       }
     };
     fetchSythesizerData();
@@ -334,7 +334,7 @@ export const Answer = ({
                   }
                   data-testid="toggle-citations-list"
                 >
-                  <Text  className={styles.accordionTitle}>
+                  <Text className={styles.accordionTitle}>
                     <span data-testid="no-of-references">
                       {parsedAnswer.citations.length > 1
                         ? parsedAnswer.citations.length + " references"
@@ -375,7 +375,7 @@ export const Answer = ({
                   onKeyDown={(e) =>
                     e.key === " " || e.key === "Enter"
                       ? onCitationClicked(citation)
-                      : () => {}
+                      : () => { }
                   }
                   tabIndex={0}
                   title={createCitationFilepath(citation, ++idx)}

--- a/code/tests/functional/tests/backend_api/default/test_speech_token.py
+++ b/code/tests/functional/tests/backend_api/default/test_speech_token.py
@@ -20,7 +20,6 @@ def test_speech_token_returned(app_url: str, app_config: AppConfig):
         "token": "speech-token",
         "region": app_config.get("AZURE_SPEECH_SERVICE_REGION"),
         "languages": app_config.get("AZURE_SPEECH_RECOGNIZER_LANGUAGES").split(","),
-        "key": "some-azure-speech-service-key",
     }
     assert response.headers["Content-Type"] == "application/json"
 

--- a/code/tests/test_app.py
+++ b/code/tests/test_app.py
@@ -115,7 +115,6 @@ class TestSpeechToken:
             "token": "speech-token",
             "region": AZURE_SPEECH_SERVICE_REGION,
             "languages": AZURE_SPEECH_RECOGNIZER_LANGUAGES,
-            "key": "mock-speech-key",
         }
 
         requests.post.assert_called_once_with(
@@ -159,7 +158,6 @@ class TestSpeechToken:
             "token": "speech-token",
             "region": AZURE_SPEECH_SERVICE_REGION,
             "languages": AZURE_SPEECH_RECOGNIZER_LANGUAGES,
-            "key": "mock-key1",
         }
 
         requests.post.assert_called_once_with(


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

The purpose of this pull request is to enhance the security of the **Speech Synthesis** integration by eliminating the exposure of the **Azure Speech API key** in browser network calls.

Previously, the frontend received and used the Speech API subscription key directly to initialize the speech synthesizer, which could be viewed in browser developer tools. While access to the app is restricted via Entra ID, exposing sensitive keys in client-side code is still a security risk.

To resolve this, we have:

- Replaced the use of the long-lived Speech API key with a short-lived authorization token retrieved securely from the backend.
- Updated both backend and frontend code to support token-based initialization of the Azure Speech Synthesizer.

This change ensures sensitive credentials are no longer exposed to end users and follows best practices for secure API consumption.

### Backend changes:

* Removed the `key` field from the `speech_config` response in `code/create_app.py`, as the backend no longer provides the subscription key.

### Frontend changes:

* Replaced the `key` field with `token` in the `synthesizerData` state in `Answer.tsx`.
* Updated the `initializeSynthesizer` function to use `SpeechConfig.fromAuthorizationToken` instead of `SpeechConfig.fromSubscription`, reflecting the switch to token-based authentication.
* Adjusted the `useEffect` logic to check for a non-empty `token` instead of `key` before initializing the synthesizer.
* Updated the `fetchSynthesizerData` function to set the `token` field in `synthesizerData` instead of `key`. Minor formatting improvement was also made to the error logging.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```


## What to Check
Verify that the following are valid:

- Speech synthesis works correctly with the new token-based setup.
- No API key is visible in browser network calls.
- Token is properly fetched from the backend and used on the frontend.
- No functional regressions introduced in the chat or speech flow.

