### PR TITLE
fix: Replace DefaultAzureCredential with ManagedIdentityCredential for production-safe authentication

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -60,6 +60,8 @@ AZURE_SPEECH_SERVICE_REGION=
 AZURE_AUTH_TYPE=keys
 USE_KEY_VAULT=true
 AZURE_KEY_VAULT_ENDPOINT=
+# Application environment (e.g., dev, prod)
+APP_ENV="dev"
 # Chat conversation type to decide between custom or byod (bring your own data) conversation type
 CONVERSATION_FLOW=
 # Chat History CosmosDB Integration Settings

--- a/code/backend/batch/utilities/chat_history/database_factory.py
+++ b/code/backend/batch/utilities/chat_history/database_factory.py
@@ -2,7 +2,7 @@
 from ..helpers.env_helper import EnvHelper
 from .cosmosdb import CosmosConversationClient
 from .postgresdbservice import PostgresConversationClient
-from azure.identity import DefaultAzureCredential
+from ..helpers.azure_credential_utils import get_azure_credential
 from ..helpers.config.database_type import DatabaseType
 
 
@@ -25,7 +25,7 @@ class DatabaseFactory:
                 f"https://{env_helper.AZURE_COSMOSDB_ACCOUNT}.documents.azure.com:443/"
             )
             credential = (
-                DefaultAzureCredential()
+                get_azure_credential()
                 if not env_helper.AZURE_COSMOSDB_ACCOUNT_KEY
                 else env_helper.AZURE_COSMOSDB_ACCOUNT_KEY
             )

--- a/code/backend/batch/utilities/chat_history/postgresdbservice.py
+++ b/code/backend/batch/utilities/chat_history/postgresdbservice.py
@@ -1,7 +1,7 @@
 import logging
 import asyncpg
 from datetime import datetime, timezone
-from azure.identity import DefaultAzureCredential
+from ..helpers.azure_credential_utils import get_azure_credential
 
 from .database_client_base import DatabaseClientBase
 
@@ -21,7 +21,7 @@ class PostgresConversationClient(DatabaseClientBase):
 
     async def connect(self):
         try:
-            credential = DefaultAzureCredential()
+            credential = get_azure_credential()
             token = credential.get_token(
                 "https://ossrdbms-aad.database.windows.net/.default"
             ).token

--- a/code/backend/batch/utilities/helpers/azure_blob_storage_client.py
+++ b/code/backend/batch/utilities/helpers/azure_blob_storage_client.py
@@ -12,7 +12,7 @@ from azure.core.credentials import AzureNamedKeyCredential
 from azure.storage.queue import QueueClient, BinaryBase64EncodePolicy
 import chardet
 from .env_helper import EnvHelper
-from azure.identity import DefaultAzureCredential
+from .azure_credential_utils import get_azure_credential
 
 
 def connection_string(account_name: str, account_key: str):
@@ -25,7 +25,7 @@ def create_queue_client():
         return QueueClient(
             account_url=f"https://{env_helper.AZURE_BLOB_ACCOUNT_NAME}.queue.core.windows.net/",
             queue_name=env_helper.DOCUMENT_PROCESSING_QUEUE_NAME,
-            credential=DefaultAzureCredential(),
+            credential=get_azure_credential(),
             message_encode_policy=BinaryBase64EncodePolicy(),
         )
 
@@ -56,7 +56,7 @@ class AzureBlobStorageClient:
         if self.auth_type == "rbac":
             self.account_key = None
             self.blob_service_client = BlobServiceClient(
-                account_url=self.endpoint, credential=DefaultAzureCredential()
+                account_url=self.endpoint, credential=get_azure_credential()
             )
             self.user_delegation_key = self.request_user_delegation_key(
                 blob_service_client=self.blob_service_client

--- a/code/backend/batch/utilities/helpers/azure_computer_vision_client.py
+++ b/code/backend/batch/utilities/helpers/azure_computer_vision_client.py
@@ -1,6 +1,7 @@
 import logging
 from urllib.parse import urljoin
-from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from azure.identity import get_bearer_token_provider
+from .azure_credential_utils import get_azure_credential
 
 import requests
 from requests import Response
@@ -56,7 +57,7 @@ class AzureComputerVisionClient:
                 headers["Ocp-Apim-Subscription-Key"] = self.key
             else:
                 token_provider = get_bearer_token_provider(
-                    DefaultAzureCredential(), self.__TOKEN_SCOPE
+                    get_azure_credential(), self.__TOKEN_SCOPE
                 )
                 headers["Authorization"] = "Bearer " + token_provider()
 

--- a/code/backend/batch/utilities/helpers/azure_credential_utils.py
+++ b/code/backend/batch/utilities/helpers/azure_credential_utils.py
@@ -1,0 +1,48 @@
+import os
+from azure.identity import ManagedIdentityCredential, DefaultAzureCredential
+from azure.identity.aio import (
+    ManagedIdentityCredential as AioManagedIdentityCredential,
+    DefaultAzureCredential as AioDefaultAzureCredential,
+)
+
+
+async def get_azure_credential_async(client_id=None):
+    """
+    Returns an Azure credential asynchronously based on the application environment.
+
+    If the environment is 'dev', it uses AioDefaultAzureCredential.
+    Otherwise, it uses AioManagedIdentityCredential.
+
+    Args:
+        client_id (str, optional): The client ID for the Managed Identity Credential.
+
+    Returns:
+        Credential object: Either AioDefaultAzureCredential or AioManagedIdentityCredential.
+    """
+    if os.getenv("APP_ENV", "prod").lower() == "dev":
+        return (
+            AioDefaultAzureCredential()
+        )  # CodeQL [SM05139] Okay use of DefaultAzureCredential as it is only used in development
+    else:
+        return AioManagedIdentityCredential(client_id=client_id)
+
+
+def get_azure_credential(client_id=None):
+    """
+    Returns an Azure credential based on the application environment.
+
+    If the environment is 'dev', it uses DefaultAzureCredential.
+    Otherwise, it uses ManagedIdentityCredential.
+
+    Args:
+        client_id (str, optional): The client ID for the Managed Identity Credential.
+
+    Returns:
+        Credential object: Either DefaultAzureCredential or ManagedIdentityCredential.
+    """
+    if os.getenv("APP_ENV", "prod").lower() == "dev":
+        return (
+            DefaultAzureCredential()
+        )  # CodeQL [SM05139] Okay use of DefaultAzureCredential as it is only used in development
+    else:
+        return ManagedIdentityCredential(client_id=client_id)

--- a/code/backend/batch/utilities/helpers/azure_form_recognizer_helper.py
+++ b/code/backend/batch/utilities/helpers/azure_form_recognizer_helper.py
@@ -1,7 +1,7 @@
 import logging
 from azure.core.credentials import AzureKeyCredential
 from azure.ai.formrecognizer import DocumentAnalysisClient
-from azure.identity import DefaultAzureCredential
+from .azure_credential_utils import get_azure_credential
 import html
 import traceback
 from .env_helper import EnvHelper
@@ -19,7 +19,7 @@ class AzureFormRecognizerClient:
         if env_helper.AZURE_AUTH_TYPE == "rbac":
             self.document_analysis_client = DocumentAnalysisClient(
                 endpoint=self.AZURE_FORM_RECOGNIZER_ENDPOINT,
-                credential=DefaultAzureCredential(),
+                credential=get_azure_credential(),
                 headers={
                     "x-ms-useragent": "chat-with-your-data-solution-accelerator/1.0.0"
                 },

--- a/code/backend/batch/utilities/helpers/azure_postgres_helper.py
+++ b/code/backend/batch/utilities/helpers/azure_postgres_helper.py
@@ -1,7 +1,7 @@
 import logging
 import psycopg2
 from psycopg2.extras import execute_values, RealDictCursor
-from azure.identity import DefaultAzureCredential
+from .azure_credential_utils import get_azure_credential
 from .llm_helper import LLMHelper
 from .env_helper import EnvHelper
 
@@ -24,7 +24,7 @@ class AzurePostgresHelper:
             dbname = self.env_helper.POSTGRESQL_DATABASE
 
             # Acquire the access token
-            credential = DefaultAzureCredential()
+            credential = get_azure_credential()
             access_token = credential.get_token(
                 "https://ossrdbms-aad.database.windows.net/.default"
             )

--- a/code/backend/batch/utilities/helpers/azure_search_helper.py
+++ b/code/backend/batch/utilities/helpers/azure_search_helper.py
@@ -2,7 +2,7 @@ import logging
 from typing import Union
 from langchain_community.vectorstores import AzureSearch
 from azure.core.credentials import AzureKeyCredential
-from azure.identity import DefaultAzureCredential
+from .azure_credential_utils import get_azure_credential
 from azure.search.documents import SearchClient
 from azure.search.documents.indexes import SearchIndexClient
 from azure.search.documents.indexes.models import (
@@ -49,10 +49,10 @@ class AzureSearchHelper:
         if self.env_helper.is_auth_type_keys():
             return AzureKeyCredential(self.env_helper.AZURE_SEARCH_KEY)
         else:
-            return DefaultAzureCredential()
+            return get_azure_credential()
 
     def _create_search_client(
-        self, search_credential: Union[AzureKeyCredential, DefaultAzureCredential]
+        self, search_credential: Union[AzureKeyCredential, get_azure_credential]
     ) -> SearchClient:
         return SearchClient(
             endpoint=self.env_helper.AZURE_SEARCH_SERVICE,
@@ -61,7 +61,7 @@ class AzureSearchHelper:
         )
 
     def _create_search_index_client(
-        self, search_credential: Union[AzureKeyCredential, DefaultAzureCredential]
+        self, search_credential: Union[AzureKeyCredential, get_azure_credential]
     ):
         return SearchIndexClient(
             endpoint=self.env_helper.AZURE_SEARCH_SERVICE, credential=search_credential
@@ -285,7 +285,7 @@ class AzureSearchHelper:
         ]
 
         if self.env_helper.AZURE_AUTH_TYPE == "rbac":
-            credential = DefaultAzureCredential()
+            credential = get_azure_credential()
             return AzureSearch(
                 azure_search_endpoint=self.env_helper.AZURE_SEARCH_SERVICE,
                 azure_search_key=None,  # Remove API key

--- a/code/backend/batch/utilities/helpers/env_helper.py
+++ b/code/backend/batch/utilities/helpers/env_helper.py
@@ -3,9 +3,9 @@ import os
 import logging
 import threading
 from dotenv import load_dotenv
-from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from azure.identity import get_bearer_token_provider
+from .azure_credential_utils import get_azure_credential
 from azure.keyvault.secrets import SecretClient
-
 from ..orchestrator.orchestration_strategy import OrchestrationStrategy
 from ..helpers.config.conversation_flow import ConversationFlow
 from ..helpers.config.database_type import DatabaseType
@@ -216,7 +216,7 @@ class EnvHelper:
         )
 
         self.AZURE_TOKEN_PROVIDER = get_bearer_token_provider(
-            DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+            get_azure_credential(), "https://cognitiveservices.azure.com/.default"
         )
         self.ADVANCED_IMAGE_PROCESSING_MAX_IMAGES = self.get_env_var_int(
             "ADVANCED_IMAGE_PROCESSING_MAX_IMAGES", 1
@@ -362,8 +362,8 @@ class EnvHelper:
         self.OPEN_AI_FUNCTIONS_SYSTEM_PROMPT = os.getenv(
             "OPEN_AI_FUNCTIONS_SYSTEM_PROMPT", ""
         )
-        self.SEMENTIC_KERNEL_SYSTEM_PROMPT = os.getenv(
-            "SEMENTIC_KERNEL_SYSTEM_PROMPT", ""
+        self.SEMANTIC_KERNEL_SYSTEM_PROMPT = os.getenv(
+            "SEMANTIC_KERNEL_SYSTEM_PROMPT", ""
         )
 
         self.ENFORCE_AUTH = self.get_env_var_bool("ENFORCE_AUTH", "True")
@@ -429,7 +429,7 @@ class SecretHelper:
         self.secret_client = None
         if self.USE_KEY_VAULT:
             self.secret_client = SecretClient(
-                os.environ.get("AZURE_KEY_VAULT_ENDPOINT"), DefaultAzureCredential()
+                os.environ.get("AZURE_KEY_VAULT_ENDPOINT"), get_azure_credential()
             )
 
     def get_secret(self, secret_name: str) -> str:

--- a/code/backend/batch/utilities/helpers/llm_helper.py
+++ b/code/backend/batch/utilities/helpers/llm_helper.py
@@ -8,7 +8,7 @@ from semantic_kernel.connectors.ai.open_ai.prompt_execution_settings.azure_chat_
     AzureChatPromptExecutionSettings,
 )
 from azure.ai.ml import MLClient
-from azure.identity import DefaultAzureCredential
+from .azure_credential_utils import get_azure_credential
 from .env_helper import EnvHelper
 
 logger = logging.getLogger(__name__)
@@ -166,7 +166,7 @@ class LLMHelper:
     def get_ml_client(self):
         if not hasattr(self, "_ml_client"):
             self._ml_client = MLClient(
-                DefaultAzureCredential(),
+                get_azure_credential(),
                 self.env_helper.AZURE_SUBSCRIPTION_ID,
                 self.env_helper.AZURE_RESOURCE_GROUP,
                 self.env_helper.AZURE_ML_WORKSPACE_NAME,

--- a/code/backend/batch/utilities/integrated_vectorization/azure_search_datasource.py
+++ b/code/backend/batch/utilities/integrated_vectorization/azure_search_datasource.py
@@ -7,7 +7,7 @@ from azure.search.documents.indexes._generated.models import (
 )
 from azure.search.documents.indexes import SearchIndexerClient
 from ..helpers.env_helper import EnvHelper
-from azure.identity import DefaultAzureCredential
+from ..helpers.azure_credential_utils import get_azure_credential
 from azure.core.credentials import AzureKeyCredential
 
 
@@ -19,7 +19,7 @@ class AzureSearchDatasource:
             (
                 AzureKeyCredential(self.env_helper.AZURE_SEARCH_KEY)
                 if self.env_helper.is_auth_type_keys()
-                else DefaultAzureCredential()
+                else get_azure_credential()
             ),
         )
 

--- a/code/backend/batch/utilities/integrated_vectorization/azure_search_index.py
+++ b/code/backend/batch/utilities/integrated_vectorization/azure_search_index.py
@@ -21,7 +21,7 @@ from azure.search.documents.indexes.models import (
     SearchIndex,
 )
 from ..helpers.env_helper import EnvHelper
-from azure.identity import DefaultAzureCredential
+from ..helpers.azure_credential_utils import get_azure_credential
 from azure.core.credentials import AzureKeyCredential
 from ..helpers.llm_helper import LLMHelper
 
@@ -39,7 +39,7 @@ class AzureSearchIndex:
             (
                 AzureKeyCredential(self.env_helper.AZURE_SEARCH_KEY)
                 if self.env_helper.is_auth_type_keys()
-                else DefaultAzureCredential()
+                else get_azure_credential()
             ),
         )
 

--- a/code/backend/batch/utilities/integrated_vectorization/azure_search_indexer.py
+++ b/code/backend/batch/utilities/integrated_vectorization/azure_search_indexer.py
@@ -2,7 +2,7 @@ import logging
 from azure.search.documents.indexes.models import SearchIndexer, FieldMapping
 from azure.search.documents.indexes import SearchIndexerClient
 from ..helpers.env_helper import EnvHelper
-from azure.identity import DefaultAzureCredential
+from ..helpers.azure_credential_utils import get_azure_credential
 from azure.core.credentials import AzureKeyCredential
 
 logger = logging.getLogger(__name__)
@@ -16,7 +16,7 @@ class AzureSearchIndexer:
             (
                 AzureKeyCredential(self.env_helper.AZURE_SEARCH_KEY)
                 if self.env_helper.is_auth_type_keys()
-                else DefaultAzureCredential()
+                else get_azure_credential()
             ),
         )
 

--- a/code/backend/batch/utilities/integrated_vectorization/azure_search_skillset.py
+++ b/code/backend/batch/utilities/integrated_vectorization/azure_search_skillset.py
@@ -15,7 +15,7 @@ from azure.search.documents.indexes.models import (
 from azure.search.documents.indexes import SearchIndexerClient
 from ..helpers.config.config_helper import IntegratedVectorizationConfig
 from ..helpers.env_helper import EnvHelper
-from azure.identity import DefaultAzureCredential
+from ..helpers.azure_credential_utils import get_azure_credential
 from azure.core.credentials import AzureKeyCredential
 
 logger = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ class AzureSearchSkillset:
             (
                 AzureKeyCredential(self.env_helper.AZURE_SEARCH_KEY)
                 if self.env_helper.is_auth_type_keys()
-                else DefaultAzureCredential()
+                else get_azure_credential()
             ),
         )
         self.integrated_vectorization_config = integrated_vectorization_config

--- a/code/backend/batch/utilities/orchestrator/semantic_kernel.py
+++ b/code/backend/batch/utilities/orchestrator/semantic_kernel.py
@@ -41,7 +41,7 @@ class SemanticKernelOrchestrator(OrchestratorBase):
             if response := self.call_content_safety_input(user_message):
                 return response
 
-        system_message = self.env_helper.SEMENTIC_KERNEL_SYSTEM_PROMPT
+        system_message = self.env_helper.SEMANTIC_KERNEL_SYSTEM_PROMPT
         if not system_message:
             system_message = """You help employees to navigate only private information sources.
 You must prioritize the function call over your general knowledge for any question by calling the search_documents function.

--- a/code/backend/batch/utilities/search/integrated_vectorization_search_handler.py
+++ b/code/backend/batch/utilities/search/integrated_vectorization_search_handler.py
@@ -5,7 +5,7 @@ from azure.search.documents import SearchClient
 from azure.search.documents.indexes import SearchIndexClient
 from azure.search.documents.models import VectorizableTextQuery
 from azure.core.credentials import AzureKeyCredential
-from azure.identity import DefaultAzureCredential
+from ..helpers.azure_credential_utils import get_azure_credential
 from ..common.source_document import SourceDocument
 import re
 
@@ -21,7 +21,7 @@ class IntegratedVectorizationSearchHandler(SearchHandlerBase):
                 credential=(
                     AzureKeyCredential(self.env_helper.AZURE_SEARCH_KEY)
                     if self.env_helper.is_auth_type_keys()
-                    else DefaultAzureCredential()
+                    else get_azure_credential()
                 ),
             )
 
@@ -170,7 +170,7 @@ class IntegratedVectorizationSearchHandler(SearchHandlerBase):
             credential=(
                 AzureKeyCredential(self.env_helper.AZURE_SEARCH_KEY)
                 if self.env_helper.is_auth_type_keys()
-                else DefaultAzureCredential()
+                else get_azure_credential()
             ),
         )
 

--- a/code/backend/batch/utilities/tools/content_safety_checker.py
+++ b/code/backend/batch/utilities/tools/content_safety_checker.py
@@ -1,7 +1,7 @@
 import logging
 from azure.ai.contentsafety import ContentSafetyClient
 from azure.core.credentials import AzureKeyCredential
-from azure.identity import DefaultAzureCredential
+from ..helpers.azure_credential_utils import get_azure_credential
 from azure.core.exceptions import HttpResponseError
 from azure.ai.contentsafety.models import AnalyzeTextOptions
 from ..helpers.env_helper import EnvHelper
@@ -19,7 +19,7 @@ class ContentSafetyChecker(AnswerProcessingBase):
             logger.info("Initializing ContentSafetyClient with RBAC authentication.")
             self.content_safety_client = ContentSafetyClient(
                 env_helper.AZURE_CONTENT_SAFETY_ENDPOINT,
-                DefaultAzureCredential(),
+                get_azure_credential(),
             )
         else:
             logger.info(

--- a/code/create_app.py
+++ b/code/create_app.py
@@ -22,7 +22,7 @@ from backend.batch.utilities.helpers.config.config_helper import ConfigHelper
 from backend.batch.utilities.helpers.config.conversation_flow import ConversationFlow
 from backend.api.chat_history import bp_chat_history_response
 from azure.mgmt.cognitiveservices import CognitiveServicesManagementClient
-from azure.identity import DefaultAzureCredential
+from backend.batch.utilities.helpers.azure_credential_utils import get_azure_credential
 from backend.batch.utilities.helpers.azure_blob_storage_client import (
     AzureBlobStorageClient,
 )
@@ -381,7 +381,7 @@ def get_speech_key(env_helper: EnvHelper):
     This is required to generate short-lived tokens when using RBAC.
     """
     client = CognitiveServicesManagementClient(
-        credential=DefaultAzureCredential(),
+        credential=get_azure_credential(),
         subscription_id=env_helper.AZURE_SUBSCRIPTION_ID,
     )
     keys = client.accounts.list_keys(

--- a/code/tests/chat_history/test_database_factory.py
+++ b/code/tests/chat_history/test_database_factory.py
@@ -8,7 +8,7 @@ from backend.batch.utilities.chat_history.postgresdbservice import (
 )
 
 
-@patch("backend.batch.utilities.chat_history.database_factory.DefaultAzureCredential")
+@patch("backend.batch.utilities.chat_history.database_factory.get_azure_credential")
 @patch("backend.batch.utilities.chat_history.database_factory.EnvHelper")
 @patch(
     "backend.batch.utilities.chat_history.database_factory.CosmosConversationClient",
@@ -50,7 +50,7 @@ def test_get_conversation_client_cosmos(
     assert client == mock_cosmos_instance
 
 
-@patch("backend.batch.utilities.chat_history.database_factory.DefaultAzureCredential")
+@patch("backend.batch.utilities.chat_history.database_factory.get_azure_credential")
 @patch("backend.batch.utilities.chat_history.database_factory.EnvHelper")
 @patch(
     "backend.batch.utilities.chat_history.database_factory.PostgresConversationClient",

--- a/code/tests/chat_history/test_postgresdbservice.py
+++ b/code/tests/chat_history/test_postgresdbservice.py
@@ -21,10 +21,10 @@ def mock_connection():
 
 
 @patch("backend.batch.utilities.chat_history.postgresdbservice.asyncpg.connect")
-@patch("backend.batch.utilities.chat_history.postgresdbservice.DefaultAzureCredential")
+@patch("backend.batch.utilities.chat_history.postgresdbservice.get_azure_credential")
 @pytest.mark.asyncio
 async def test_connect(mock_credential, mock_connect, postgres_client, mock_connection):
-    # Mock DefaultAzureCredential
+    # Mock get_azure_credential
     mock_credential.return_value.get_token.return_value.token = "mock_token"
 
     # Mock asyncpg connection

--- a/code/tests/utilities/helpers/test_azure_computer_vision_client.py
+++ b/code/tests/utilities/helpers/test_azure_computer_vision_client.py
@@ -94,7 +94,7 @@ def test_vectorize_image_calls_computer_vision_with_key_based_authentication(
 
 
 @mock.patch(
-    "backend.batch.utilities.helpers.azure_computer_vision_client.DefaultAzureCredential"
+    "backend.batch.utilities.helpers.azure_computer_vision_client.get_azure_credential"
 )
 @mock.patch(
     "backend.batch.utilities.helpers.azure_computer_vision_client.get_bearer_token_provider"

--- a/code/tests/utilities/helpers/test_azure_credential_utils.py
+++ b/code/tests/utilities/helpers/test_azure_credential_utils.py
@@ -2,17 +2,18 @@ import sys
 import os
 from unittest.mock import patch, MagicMock
 import pytest
-import helpers.azure_credential_utils as azure_credential_utils
+import backend.batch.utilities.helpers.azure_credential_utils as azure_credential_utils
 
-# Ensure src/backend is on the Python path for imports
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 # Synchronous tests
 
 
-@patch("helpers.azure_credential_utils.os.getenv")
-@patch("helpers.azure_credential_utils.DefaultAzureCredential")
-@patch("helpers.azure_credential_utils.ManagedIdentityCredential")
+@patch("backend.batch.utilities.helpers.azure_credential_utils.os.getenv")
+@patch("backend.batch.utilities.helpers.azure_credential_utils.DefaultAzureCredential")
+@patch(
+    "backend.batch.utilities.helpers.azure_credential_utils.ManagedIdentityCredential"
+)
 def test_get_azure_credential_dev_env(
     mock_managed_identity_credential, mock_default_azure_credential, mock_getenv
 ):
@@ -29,9 +30,11 @@ def test_get_azure_credential_dev_env(
     assert credential == mock_default_credential
 
 
-@patch("helpers.azure_credential_utils.os.getenv")
-@patch("helpers.azure_credential_utils.DefaultAzureCredential")
-@patch("helpers.azure_credential_utils.ManagedIdentityCredential")
+@patch("backend.batch.utilities.helpers.azure_credential_utils.os.getenv")
+@patch("backend.batch.utilities.helpers.azure_credential_utils.DefaultAzureCredential")
+@patch(
+    "backend.batch.utilities.helpers.azure_credential_utils.ManagedIdentityCredential"
+)
 def test_get_azure_credential_non_dev_env(
     mock_managed_identity_credential, mock_default_azure_credential, mock_getenv
 ):
@@ -51,9 +54,13 @@ def test_get_azure_credential_non_dev_env(
 
 
 @pytest.mark.asyncio
-@patch("helpers.azure_credential_utils.os.getenv")
-@patch("helpers.azure_credential_utils.AioDefaultAzureCredential")
-@patch("helpers.azure_credential_utils.AioManagedIdentityCredential")
+@patch("backend.batch.utilities.helpers.azure_credential_utils.os.getenv")
+@patch(
+    "backend.batch.utilities.helpers.azure_credential_utils.AioDefaultAzureCredential"
+)
+@patch(
+    "backend.batch.utilities.helpers.azure_credential_utils.AioManagedIdentityCredential"
+)
 async def test_get_azure_credential_async_dev_env(
     mock_aio_managed_identity_credential, mock_aio_default_azure_credential, mock_getenv
 ):
@@ -71,9 +78,13 @@ async def test_get_azure_credential_async_dev_env(
 
 
 @pytest.mark.asyncio
-@patch("helpers.azure_credential_utils.os.getenv")
-@patch("helpers.azure_credential_utils.AioDefaultAzureCredential")
-@patch("helpers.azure_credential_utils.AioManagedIdentityCredential")
+@patch("backend.batch.utilities.helpers.azure_credential_utils.os.getenv")
+@patch(
+    "backend.batch.utilities.helpers.azure_credential_utils.AioDefaultAzureCredential"
+)
+@patch(
+    "backend.batch.utilities.helpers.azure_credential_utils.AioManagedIdentityCredential"
+)
 async def test_get_azure_credential_async_non_dev_env(
     mock_aio_managed_identity_credential, mock_aio_default_azure_credential, mock_getenv
 ):

--- a/code/tests/utilities/helpers/test_azure_credential_utils.py
+++ b/code/tests/utilities/helpers/test_azure_credential_utils.py
@@ -1,0 +1,94 @@
+import sys
+import os
+from unittest.mock import patch, MagicMock
+import pytest
+import helpers.azure_credential_utils as azure_credential_utils
+
+# Ensure src/backend is on the Python path for imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+# Synchronous tests
+
+
+@patch("helpers.azure_credential_utils.os.getenv")
+@patch("helpers.azure_credential_utils.DefaultAzureCredential")
+@patch("helpers.azure_credential_utils.ManagedIdentityCredential")
+def test_get_azure_credential_dev_env(
+    mock_managed_identity_credential, mock_default_azure_credential, mock_getenv
+):
+    """Test get_azure_credential in dev environment."""
+    mock_getenv.return_value = "dev"
+    mock_default_credential = MagicMock()
+    mock_default_azure_credential.return_value = mock_default_credential
+
+    credential = azure_credential_utils.get_azure_credential()
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_default_azure_credential.assert_called_once()
+    mock_managed_identity_credential.assert_not_called()
+    assert credential == mock_default_credential
+
+
+@patch("helpers.azure_credential_utils.os.getenv")
+@patch("helpers.azure_credential_utils.DefaultAzureCredential")
+@patch("helpers.azure_credential_utils.ManagedIdentityCredential")
+def test_get_azure_credential_non_dev_env(
+    mock_managed_identity_credential, mock_default_azure_credential, mock_getenv
+):
+    """Test get_azure_credential in non-dev environment."""
+    mock_getenv.return_value = "prod"
+    mock_managed_credential = MagicMock()
+    mock_managed_identity_credential.return_value = mock_managed_credential
+    credential = azure_credential_utils.get_azure_credential(client_id="test-client-id")
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_managed_identity_credential.assert_called_once_with(client_id="test-client-id")
+    mock_default_azure_credential.assert_not_called()
+    assert credential == mock_managed_credential
+
+
+# Asynchronous tests
+
+
+@pytest.mark.asyncio
+@patch("helpers.azure_credential_utils.os.getenv")
+@patch("helpers.azure_credential_utils.AioDefaultAzureCredential")
+@patch("helpers.azure_credential_utils.AioManagedIdentityCredential")
+async def test_get_azure_credential_async_dev_env(
+    mock_aio_managed_identity_credential, mock_aio_default_azure_credential, mock_getenv
+):
+    """Test get_azure_credential_async in dev environment."""
+    mock_getenv.return_value = "dev"
+    mock_aio_default_credential = MagicMock()
+    mock_aio_default_azure_credential.return_value = mock_aio_default_credential
+
+    credential = await azure_credential_utils.get_azure_credential_async()
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_aio_default_azure_credential.assert_called_once()
+    mock_aio_managed_identity_credential.assert_not_called()
+    assert credential == mock_aio_default_credential
+
+
+@pytest.mark.asyncio
+@patch("helpers.azure_credential_utils.os.getenv")
+@patch("helpers.azure_credential_utils.AioDefaultAzureCredential")
+@patch("helpers.azure_credential_utils.AioManagedIdentityCredential")
+async def test_get_azure_credential_async_non_dev_env(
+    mock_aio_managed_identity_credential, mock_aio_default_azure_credential, mock_getenv
+):
+    """Test get_azure_credential_async in non-dev environment."""
+    mock_getenv.return_value = "prod"
+    mock_aio_managed_credential = MagicMock()
+    mock_aio_managed_identity_credential.return_value = mock_aio_managed_credential
+
+    credential = await azure_credential_utils.get_azure_credential_async(
+        client_id="test-client-id"
+    )
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_aio_managed_identity_credential.assert_called_once_with(
+        client_id="test-client-id"
+    )
+    mock_aio_default_azure_credential.assert_not_called()
+    assert credential == mock_aio_managed_credential

--- a/code/tests/utilities/helpers/test_azure_postgres_helper.py
+++ b/code/tests/utilities/helpers/test_azure_postgres_helper.py
@@ -5,9 +5,7 @@ from backend.batch.utilities.helpers.azure_postgres_helper import AzurePostgresH
 
 
 class TestAzurePostgresHelper(unittest.TestCase):
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     def test_create_search_client_success(self, mock_connect, mock_credential):
         # Arrange
@@ -52,14 +50,10 @@ class TestAzurePostgresHelper(unittest.TestCase):
         self.assertEqual(connection, mock_connection)
         mock_connect.assert_not_called()  # Ensure no new connection is created
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.RealDictCursor")
-    def test_get_vector_store_success(
-        self, mock_cursor, mock_connect, mock_credential
-    ):
+    def test_get_vector_store_success(self, mock_cursor, mock_connect, mock_credential):
         # Arrange
         # Mock the EnvHelper and set required attributes
         mock_env_helper = MagicMock()
@@ -101,9 +95,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
             "host=mock_host user=mock_user dbname=mock_database password=mock-access-token"
         )
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     def test_get_vector_store_query_error(self, mock_connect, mock_credential):
         # Arrange
@@ -142,9 +134,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
 
         self.assertEqual(str(context.exception), "Query execution error")
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     def test_create_search_client_connection_error(self, mock_connect, mock_credential):
         # Arrange
@@ -174,9 +164,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
 
         self.assertEqual(str(context.exception), "Connection error")
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
     def test_get_files_success(self, mock_env_helper, mock_connect, mock_credential):
@@ -215,9 +203,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         )
         mock_connection.close.assert_called_once()
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
     def test_get_files_no_results(self, mock_env_helper, mock_connect, mock_credential):
@@ -251,9 +237,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         self.assertIsNone(result)
         mock_connection.close.assert_called_once()
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.logger")
@@ -292,9 +276,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         )
         mock_connection.close.assert_called_once()
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.logger")
@@ -333,9 +315,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         )
         mock_connection.close.assert_called_once()
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.logger")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
@@ -377,9 +357,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         mock_connection.close.assert_called_once()
         mock_logger.info.assert_called_with("Deleted 3 documents.")
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.logger")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
@@ -417,9 +395,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         mock_logger.warning.assert_called_with("No IDs provided for deletion.")
         mock_connection.close.assert_called_once()
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.logger")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
@@ -461,9 +437,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         mock_connection.rollback.assert_called_once()
         mock_connection.close.assert_called_once()
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.logger")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
@@ -505,9 +479,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         mock_connection.rollback.assert_called_once()
         mock_connection.close.assert_called_once()
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.logger")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
@@ -558,9 +530,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         mock_connection.close.assert_called_once()
         mock_logger.info.assert_called_with("Retrieved 1 search result(s).")
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.logger")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
@@ -602,9 +572,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         mock_connection.close.assert_called_once()
         mock_logger.info.assert_called_with("Retrieved 0 search result(s).")
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.logger")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
@@ -645,9 +613,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         )
         mock_connection.close.assert_called_once()
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.logger")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
@@ -692,9 +658,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         mock_connection.close.assert_called_once()
         mock_logger.info.assert_called_with("Retrieved 2 unique title(s).")
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.logger")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
@@ -734,9 +698,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         mock_connection.close.assert_called_once()
         mock_logger.info.assert_called_with("Retrieved 0 unique title(s).")
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.logger")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
@@ -775,9 +737,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         )
         mock_connection.close.assert_called_once()
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.logger")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
@@ -823,9 +783,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         mock_connection.close.assert_called_once()
         mock_logger.info.assert_called_with("Retrieved 2 unique title(s).")
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.logger")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")
@@ -866,9 +824,7 @@ class TestAzurePostgresHelper(unittest.TestCase):
         mock_connection.close.assert_called_once()
         mock_logger.info.assert_called_with("Retrieved 0 unique title(s).")
 
-    @patch(
-        "backend.batch.utilities.helpers.azure_postgres_helper.DefaultAzureCredential"
-    )
+    @patch("backend.batch.utilities.helpers.azure_postgres_helper.get_azure_credential")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.psycopg2.connect")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.logger")
     @patch("backend.batch.utilities.helpers.azure_postgres_helper.EnvHelper")

--- a/code/tests/utilities/helpers/test_azure_search_helper.py
+++ b/code/tests/utilities/helpers/test_azure_search_helper.py
@@ -142,7 +142,7 @@ def test_creates_search_clients_with_keys(
 
 @patch("backend.batch.utilities.helpers.azure_search_helper.SearchClient")
 @patch("backend.batch.utilities.helpers.azure_search_helper.SearchIndexClient")
-@patch("backend.batch.utilities.helpers.azure_search_helper.DefaultAzureCredential")
+@patch("backend.batch.utilities.helpers.azure_search_helper.get_azure_credential")
 def test_creates_search_clients_with_rabc(
     default_azure_credential_mock: MagicMock,
     search_index_client_mock: MagicMock,

--- a/code/tests/utilities/helpers/test_llm_helper.py
+++ b/code/tests/utilities/helpers/test_llm_helper.py
@@ -139,7 +139,7 @@ def test_generate_embeddings_returns_embeddings(azure_openai_mock):
     assert actual_embeddings == expected_embeddings
 
 
-@patch("backend.batch.utilities.helpers.llm_helper.DefaultAzureCredential")
+@patch("backend.batch.utilities.helpers.llm_helper.get_azure_credential")
 @patch("backend.batch.utilities.helpers.llm_helper.MLClient")
 def test_get_ml_client_initializes_with_expected_parameters(
     mock_ml_client, mock_default_credential, env_helper_mock

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -300,6 +300,9 @@ param searchTag string = 'chatwithyourdata-sa'
 @description('Id of the user or app to assign application roles')
 param principalId string = ''
 
+@description('Application Environment')
+param appEnvironment string = 'Prod'
+
 @description('Hosting model for the web apps. This value is fixed as "container", which uses prebuilt containers for faster deployment.')
 param hostingModel string = 'container'
 
@@ -326,8 +329,8 @@ var tags = { 'azd-env-name': environmentName }
 var keyVaultName = '${abbrs.security.keyVault}${resourceToken}'
 var baseUrl = 'https://raw.githubusercontent.com/Azure-Samples/chat-with-your-data-solution-accelerator/main/'
 
-var appversion = 'latest' // Update GIT deployment branch
-var registryName = 'cwydcontainerreg' // Update Registry name
+var appversion = 'latest' // Set the application version for container image tags
+var registryName = 'cwydcontainerreg' // Name of the Azure Container Registry to use for container images
 
 var openAIFunctionsSystemPrompt = '''You help employees to navigate only private information sources.
     You must prioritize the function call over your general knowledge for any question by calling the search_documents function.
@@ -621,7 +624,6 @@ module web './app/web.bicep' = if (hostingModel == 'code') {
         AZURE_OPENAI_EMBEDDING_MODEL: azureOpenAIEmbeddingModel
         AZURE_OPENAI_EMBEDDING_MODEL_NAME: azureOpenAIEmbeddingModelName
         AZURE_OPENAI_EMBEDDING_MODEL_VERSION: azureOpenAIEmbeddingModelVersion
-
         AZURE_SPEECH_SERVICE_NAME: speechServiceName
         AZURE_SPEECH_SERVICE_REGION: location
         AZURE_SPEECH_RECOGNIZER_LANGUAGES: recognizedLanguages
@@ -632,7 +634,8 @@ module web './app/web.bicep' = if (hostingModel == 'code') {
         LOGLEVEL: logLevel
         DATABASE_TYPE: databaseType
         OPEN_AI_FUNCTIONS_SYSTEM_PROMPT: openAIFunctionsSystemPrompt
-        SEMENTIC_KERNEL_SYSTEM_PROMPT: semanticKernelSystemPrompt
+        SEMANTIC_KERNEL_SYSTEM_PROMPT: semanticKernelSystemPrompt
+        APP_ENV: appEnvironment
       },
       // Conditionally add database-specific settings
       databaseType == 'CosmosDB'
@@ -713,7 +716,6 @@ module web_docker './app/web.bicep' = if (hostingModel == 'container') {
         AZURE_OPENAI_EMBEDDING_MODEL: azureOpenAIEmbeddingModel
         AZURE_OPENAI_EMBEDDING_MODEL_NAME: azureOpenAIEmbeddingModelName
         AZURE_OPENAI_EMBEDDING_MODEL_VERSION: azureOpenAIEmbeddingModelVersion
-
         AZURE_SPEECH_SERVICE_NAME: speechServiceName
         AZURE_SPEECH_SERVICE_REGION: location
         AZURE_SPEECH_RECOGNIZER_LANGUAGES: recognizedLanguages
@@ -724,7 +726,8 @@ module web_docker './app/web.bicep' = if (hostingModel == 'container') {
         LOGLEVEL: logLevel
         DATABASE_TYPE: databaseType
         OPEN_AI_FUNCTIONS_SYSTEM_PROMPT: openAIFunctionsSystemPrompt
-        SEMENTIC_KERNEL_SYSTEM_PROMPT: semanticKernelSystemPrompt
+        SEMANTIC_KERNEL_SYSTEM_PROMPT: semanticKernelSystemPrompt
+        APP_ENV: appEnvironment
       },
       // Conditionally add database-specific settings
       databaseType == 'CosmosDB'
@@ -802,7 +805,6 @@ module adminweb './app/adminweb.bicep' = if (hostingModel == 'code') {
         AZURE_OPENAI_EMBEDDING_MODEL: azureOpenAIEmbeddingModel
         AZURE_OPENAI_EMBEDDING_MODEL_NAME: azureOpenAIEmbeddingModelName
         AZURE_OPENAI_EMBEDDING_MODEL_VERSION: azureOpenAIEmbeddingModelVersion
-
         USE_ADVANCED_IMAGE_PROCESSING: useAdvancedImageProcessing
         BACKEND_URL: 'https://${functionName}.azurewebsites.net'
         DOCUMENT_PROCESSING_QUEUE_NAME: queueName
@@ -812,6 +814,7 @@ module adminweb './app/adminweb.bicep' = if (hostingModel == 'code') {
         LOGLEVEL: logLevel
         DATABASE_TYPE: databaseType
         USE_KEY_VAULT: 'true'
+        APP_ENV: appEnvironment
       },
       // Conditionally add database-specific settings
       databaseType == 'CosmosDB'
@@ -885,7 +888,6 @@ module adminweb_docker './app/adminweb.bicep' = if (hostingModel == 'container')
         AZURE_OPENAI_EMBEDDING_MODEL: azureOpenAIEmbeddingModel
         AZURE_OPENAI_EMBEDDING_MODEL_NAME: azureOpenAIEmbeddingModelName
         AZURE_OPENAI_EMBEDDING_MODEL_VERSION: azureOpenAIEmbeddingModelVersion
-
         USE_ADVANCED_IMAGE_PROCESSING: useAdvancedImageProcessing
         BACKEND_URL: 'https://${functionName}-docker.azurewebsites.net'
         DOCUMENT_PROCESSING_QUEUE_NAME: queueName
@@ -895,6 +897,7 @@ module adminweb_docker './app/adminweb.bicep' = if (hostingModel == 'container')
         LOGLEVEL: logLevel
         DATABASE_TYPE: databaseType
         USE_KEY_VAULT: 'true'
+        APP_ENV: appEnvironment
       },
       // Conditionally add database-specific settings
       databaseType == 'CosmosDB'
@@ -1000,13 +1003,13 @@ module function './app/function.bicep' = if (hostingModel == 'code') {
         AZURE_OPENAI_EMBEDDING_MODEL_VERSION: azureOpenAIEmbeddingModelVersion
         AZURE_OPENAI_RESOURCE: azureOpenAIResourceName
         AZURE_OPENAI_API_VERSION: azureOpenAIApiVersion
-
         USE_ADVANCED_IMAGE_PROCESSING: useAdvancedImageProcessing
         DOCUMENT_PROCESSING_QUEUE_NAME: queueName
         ORCHESTRATION_STRATEGY: orchestrationStrategy
         LOGLEVEL: logLevel
         AZURE_OPENAI_SYSTEM_MESSAGE: azureOpenAISystemMessage
         DATABASE_TYPE: databaseType
+        APP_ENV: appEnvironment
       },
       // Conditionally add database-specific settings
       databaseType == 'CosmosDB'
@@ -1069,13 +1072,13 @@ module function_docker './app/function.bicep' = if (hostingModel == 'container')
         AZURE_OPENAI_EMBEDDING_MODEL_VERSION: azureOpenAIEmbeddingModelVersion
         AZURE_OPENAI_RESOURCE: azureOpenAIResourceName
         AZURE_OPENAI_API_VERSION: azureOpenAIApiVersion
-
         USE_ADVANCED_IMAGE_PROCESSING: useAdvancedImageProcessing
         DOCUMENT_PROCESSING_QUEUE_NAME: queueName
         ORCHESTRATION_STRATEGY: orchestrationStrategy
         LOGLEVEL: logLevel
         AZURE_OPENAI_SYSTEM_MESSAGE: azureOpenAISystemMessage
         DATABASE_TYPE: databaseType
+        APP_ENV: appEnvironment
       },
       // Conditionally add database-specific settings
       databaseType == 'CosmosDB'
@@ -1330,7 +1333,7 @@ var azureSearchServiceInfo = databaseType == 'CosmosDB'
   : ''
 
 var azureComputerVisionInfo = string({
-  service_name: speechServiceName
+  service_name: computerVisionName
   endpoint: useAdvancedImageProcessing ? computerVision.outputs.endpoint : ''
   location: useAdvancedImageProcessing ? computerVision.outputs.location : ''
   vectorize_image_api_version: computerVisionVectorizeImageApiVersion
@@ -1357,6 +1360,7 @@ var backendUrl = 'https://${functionName}.azurewebsites.net'
 
 output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.applicationInsightsConnectionString
 output AZURE_APP_SERVICE_HOSTING_MODEL string = hostingModel
+output APP_ENV string = appEnvironment
 output AZURE_BLOB_STORAGE_INFO string = azureBlobStorageInfo
 output AZURE_COMPUTER_VISION_INFO string = azureComputerVisionInfo
 output AZURE_CONTENT_SAFETY_INFO string = azureContentSafetyInfo
@@ -1394,4 +1398,4 @@ output AZURE_COSMOSDB_INFO string = azureCosmosDBInfo
 output AZURE_POSTGRESQL_INFO string = azurePostgresDBInfo
 output DATABASE_TYPE string = databaseType
 output OPEN_AI_FUNCTIONS_SYSTEM_PROMPT string = openAIFunctionsSystemPrompt
-output SEMENTIC_KERNEL_SYSTEM_PROMPT string = semanticKernelSystemPrompt
+output SEMANTIC_KERNEL_SYSTEM_PROMPT string = semanticKernelSystemPrompt

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -3,6 +3,7 @@ using './main.bicep'
 param environmentName = readEnvironmentVariable('AZURE_ENV_NAME', 'env_name')
 param location = readEnvironmentVariable('AZURE_LOCATION', 'location')
 param principalId = readEnvironmentVariable('AZURE_PRINCIPAL_ID', 'principal_id')
+param appEnvironment = readEnvironmentVariable('APP_ENV', 'Prod')
 
 // Deploying using json will set this to "container".
 param hostingModel = readEnvironmentVariable('AZURE_APP_SERVICE_HOSTING_MODEL', 'code')

--- a/infra/main.json
+++ b/infra/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "6566430506441917064"
+      "version": "0.36.177.2456",
+      "templateHash": "7474194633407866724"
     }
   },
   "parameters": {
@@ -614,6 +614,13 @@
         "description": "Id of the user or app to assign application roles"
       }
     },
+    "appEnvironment": {
+      "type": "string",
+      "defaultValue": "Prod",
+      "metadata": {
+        "description": "Application Environment"
+      }
+    },
     "hostingModel": {
       "type": "string",
       "defaultValue": "container",
@@ -959,8 +966,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "13552365542706136811"
+              "version": "0.36.177.2456",
+              "templateHash": "5332626978409423867"
             }
           },
           "parameters": {
@@ -1051,8 +1058,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "16238674825125616801"
+              "version": "0.36.177.2456",
+              "templateHash": "2450648193631066644"
             }
           },
           "parameters": {
@@ -1223,8 +1230,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "18258663885754684875"
+              "version": "0.36.177.2456",
+              "templateHash": "8099859803038218986"
             }
           },
           "parameters": {
@@ -1452,8 +1459,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "13654700215438528863"
+              "version": "0.36.177.2456",
+              "templateHash": "10950365812388137062"
             },
             "description": "Creates an Azure Key Vault."
           },
@@ -1554,8 +1561,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "5396502874055092713"
+              "version": "0.36.177.2456",
+              "templateHash": "10797488511727118382"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -1713,8 +1720,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "5396502874055092713"
+              "version": "0.36.177.2456",
+              "templateHash": "10797488511727118382"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -1865,8 +1872,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "1525080529756490231"
+              "version": "0.36.177.2456",
+              "templateHash": "14223167216489085881"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -1935,8 +1942,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "1525080529756490231"
+              "version": "0.36.177.2456",
+              "templateHash": "14223167216489085881"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -2006,8 +2013,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "1525080529756490231"
+              "version": "0.36.177.2456",
+              "templateHash": "14223167216489085881"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -2077,8 +2084,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "1525080529756490231"
+              "version": "0.36.177.2456",
+              "templateHash": "14223167216489085881"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -2152,8 +2159,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "5396502874055092713"
+              "version": "0.36.177.2456",
+              "templateHash": "10797488511727118382"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -2301,8 +2308,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "15387352767143583863"
+              "version": "0.36.177.2456",
+              "templateHash": "15189588962138122860"
             }
           },
           "parameters": {
@@ -2379,8 +2386,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "7022850395133125583"
+              "version": "0.36.177.2456",
+              "templateHash": "16006377011416272456"
             },
             "description": "Creates an Azure AI Search instance."
           },
@@ -2548,8 +2555,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "8289034454652170240"
+              "version": "0.36.177.2456",
+              "templateHash": "1018313823442323683"
             },
             "description": "Creates an Azure App Service plan."
           },
@@ -2650,7 +2657,7 @@
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'keyvault'), '2022-09-01').outputs.name.value]"
           },
           "appSettings": {
-            "value": "[union(createObject('AZURE_BLOB_ACCOUNT_NAME', parameters('storageAccountName'), 'AZURE_BLOB_CONTAINER_NAME', variables('blobContainerName'), 'AZURE_FORM_RECOGNIZER_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('formRecognizerName')), '2022-09-01').outputs.endpoint.value, 'AZURE_COMPUTER_VISION_ENDPOINT', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.endpoint.value, ''), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_API_VERSION', parameters('computerVisionVectorizeImageApiVersion'), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_MODEL_VERSION', parameters('computerVisionVectorizeImageModelVersion'), 'AZURE_CONTENT_SAFETY_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('contentSafetyName')), '2022-09-01').outputs.endpoint.value, 'AZURE_OPENAI_RESOURCE', parameters('azureOpenAIResourceName'), 'AZURE_OPENAI_MODEL', parameters('azureOpenAIModel'), 'AZURE_OPENAI_MODEL_NAME', parameters('azureOpenAIModelName'), 'AZURE_OPENAI_MODEL_VERSION', parameters('azureOpenAIModelVersion'), 'AZURE_OPENAI_TEMPERATURE', parameters('azureOpenAITemperature'), 'AZURE_OPENAI_TOP_P', parameters('azureOpenAITopP'), 'AZURE_OPENAI_MAX_TOKENS', parameters('azureOpenAIMaxTokens'), 'AZURE_OPENAI_STOP_SEQUENCE', parameters('azureOpenAIStopSequence'), 'AZURE_OPENAI_SYSTEM_MESSAGE', parameters('azureOpenAISystemMessage'), 'AZURE_OPENAI_API_VERSION', parameters('azureOpenAIApiVersion'), 'AZURE_OPENAI_STREAM', parameters('azureOpenAIStream'), 'AZURE_OPENAI_EMBEDDING_MODEL', parameters('azureOpenAIEmbeddingModel'), 'AZURE_OPENAI_EMBEDDING_MODEL_NAME', parameters('azureOpenAIEmbeddingModelName'), 'AZURE_OPENAI_EMBEDDING_MODEL_VERSION', parameters('azureOpenAIEmbeddingModelVersion'), 'AZURE_SPEECH_SERVICE_NAME', parameters('speechServiceName'), 'AZURE_SPEECH_SERVICE_REGION', parameters('location'), 'AZURE_SPEECH_RECOGNIZER_LANGUAGES', parameters('recognizedLanguages'), 'USE_ADVANCED_IMAGE_PROCESSING', parameters('useAdvancedImageProcessing'), 'ADVANCED_IMAGE_PROCESSING_MAX_IMAGES', parameters('advancedImageProcessingMaxImages'), 'ORCHESTRATION_STRATEGY', parameters('orchestrationStrategy'), 'CONVERSATION_FLOW', parameters('conversationFlow'), 'LOGLEVEL', parameters('logLevel'), 'DATABASE_TYPE', parameters('databaseType'), 'OPEN_AI_FUNCTIONS_SYSTEM_PROMPT', variables('openAIFunctionsSystemPrompt'), 'SEMENTIC_KERNEL_SYSTEM_PROMPT', variables('semanticKernelSystemPrompt')), if(equals(parameters('databaseType'), 'CosmosDB'), createObject('AZURE_COSMOSDB_ACCOUNT_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosAccountName, 'AZURE_COSMOSDB_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosDatabaseName, 'AZURE_COSMOSDB_CONVERSATIONS_CONTAINER_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosContainerName, 'AZURE_COSMOSDB_ENABLE_FEEDBACK', true(), 'AZURE_SEARCH_USE_SEMANTIC_SEARCH', parameters('azureSearchUseSemanticSearch'), 'AZURE_SEARCH_SERVICE', format('https://{0}.search.windows.net', parameters('azureAISearchName')), 'AZURE_SEARCH_INDEX', parameters('azureSearchIndex'), 'AZURE_SEARCH_CONVERSATIONS_LOG_INDEX', parameters('azureSearchConversationLogIndex'), 'AZURE_SEARCH_SEMANTIC_SEARCH_CONFIG', parameters('azureSearchSemanticSearchConfig'), 'AZURE_SEARCH_INDEX_IS_PRECHUNKED', parameters('azureSearchIndexIsPrechunked'), 'AZURE_SEARCH_TOP_K', parameters('azureSearchTopK'), 'AZURE_SEARCH_ENABLE_IN_DOMAIN', parameters('azureSearchEnableInDomain'), 'AZURE_SEARCH_FILENAME_COLUMN', parameters('azureSearchFilenameColumn'), 'AZURE_SEARCH_FILTER', parameters('azureSearchFilter'), 'AZURE_SEARCH_FIELDS_ID', parameters('azureSearchFieldId'), 'AZURE_SEARCH_CONTENT_COLUMN', parameters('azureSearchContentColumn'), 'AZURE_SEARCH_CONTENT_VECTOR_COLUMN', parameters('azureSearchVectorColumn'), 'AZURE_SEARCH_TITLE_COLUMN', parameters('azureSearchTitleColumn'), 'AZURE_SEARCH_FIELDS_METADATA', parameters('azureSearchFieldsMetadata'), 'AZURE_SEARCH_SOURCE_COLUMN', parameters('azureSearchSourceColumn'), 'AZURE_SEARCH_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchTextColumn'), ''), 'AZURE_SEARCH_LAYOUT_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchLayoutTextColumn'), ''), 'AZURE_SEARCH_CHUNK_COLUMN', parameters('azureSearchChunkColumn'), 'AZURE_SEARCH_OFFSET_COLUMN', parameters('azureSearchOffsetColumn'), 'AZURE_SEARCH_URL_COLUMN', parameters('azureSearchUrlColumn'), 'AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION', parameters('azureSearchUseIntegratedVectorization')), if(equals(parameters('databaseType'), 'PostgreSQL'), createObject('AZURE_POSTGRESQL_HOST_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLServerName, 'AZURE_POSTGRESQL_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLDatabaseName, 'AZURE_POSTGRESQL_USER', parameters('websiteName')), createObject())))]"
+            "value": "[union(createObject('AZURE_BLOB_ACCOUNT_NAME', parameters('storageAccountName'), 'AZURE_BLOB_CONTAINER_NAME', variables('blobContainerName'), 'AZURE_FORM_RECOGNIZER_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('formRecognizerName')), '2022-09-01').outputs.endpoint.value, 'AZURE_COMPUTER_VISION_ENDPOINT', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.endpoint.value, ''), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_API_VERSION', parameters('computerVisionVectorizeImageApiVersion'), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_MODEL_VERSION', parameters('computerVisionVectorizeImageModelVersion'), 'AZURE_CONTENT_SAFETY_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('contentSafetyName')), '2022-09-01').outputs.endpoint.value, 'AZURE_OPENAI_RESOURCE', parameters('azureOpenAIResourceName'), 'AZURE_OPENAI_MODEL', parameters('azureOpenAIModel'), 'AZURE_OPENAI_MODEL_NAME', parameters('azureOpenAIModelName'), 'AZURE_OPENAI_MODEL_VERSION', parameters('azureOpenAIModelVersion'), 'AZURE_OPENAI_TEMPERATURE', parameters('azureOpenAITemperature'), 'AZURE_OPENAI_TOP_P', parameters('azureOpenAITopP'), 'AZURE_OPENAI_MAX_TOKENS', parameters('azureOpenAIMaxTokens'), 'AZURE_OPENAI_STOP_SEQUENCE', parameters('azureOpenAIStopSequence'), 'AZURE_OPENAI_SYSTEM_MESSAGE', parameters('azureOpenAISystemMessage'), 'AZURE_OPENAI_API_VERSION', parameters('azureOpenAIApiVersion'), 'AZURE_OPENAI_STREAM', parameters('azureOpenAIStream'), 'AZURE_OPENAI_EMBEDDING_MODEL', parameters('azureOpenAIEmbeddingModel'), 'AZURE_OPENAI_EMBEDDING_MODEL_NAME', parameters('azureOpenAIEmbeddingModelName'), 'AZURE_OPENAI_EMBEDDING_MODEL_VERSION', parameters('azureOpenAIEmbeddingModelVersion'), 'AZURE_SPEECH_SERVICE_NAME', parameters('speechServiceName'), 'AZURE_SPEECH_SERVICE_REGION', parameters('location'), 'AZURE_SPEECH_RECOGNIZER_LANGUAGES', parameters('recognizedLanguages'), 'USE_ADVANCED_IMAGE_PROCESSING', parameters('useAdvancedImageProcessing'), 'ADVANCED_IMAGE_PROCESSING_MAX_IMAGES', parameters('advancedImageProcessingMaxImages'), 'ORCHESTRATION_STRATEGY', parameters('orchestrationStrategy'), 'CONVERSATION_FLOW', parameters('conversationFlow'), 'LOGLEVEL', parameters('logLevel'), 'DATABASE_TYPE', parameters('databaseType'), 'OPEN_AI_FUNCTIONS_SYSTEM_PROMPT', variables('openAIFunctionsSystemPrompt'), 'SEMANTIC_KERNEL_SYSTEM_PROMPT', variables('semanticKernelSystemPrompt'), 'APP_ENV', parameters('appEnvironment')), if(equals(parameters('databaseType'), 'CosmosDB'), createObject('AZURE_COSMOSDB_ACCOUNT_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosAccountName, 'AZURE_COSMOSDB_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosDatabaseName, 'AZURE_COSMOSDB_CONVERSATIONS_CONTAINER_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosContainerName, 'AZURE_COSMOSDB_ENABLE_FEEDBACK', true(), 'AZURE_SEARCH_USE_SEMANTIC_SEARCH', parameters('azureSearchUseSemanticSearch'), 'AZURE_SEARCH_SERVICE', format('https://{0}.search.windows.net', parameters('azureAISearchName')), 'AZURE_SEARCH_INDEX', parameters('azureSearchIndex'), 'AZURE_SEARCH_CONVERSATIONS_LOG_INDEX', parameters('azureSearchConversationLogIndex'), 'AZURE_SEARCH_SEMANTIC_SEARCH_CONFIG', parameters('azureSearchSemanticSearchConfig'), 'AZURE_SEARCH_INDEX_IS_PRECHUNKED', parameters('azureSearchIndexIsPrechunked'), 'AZURE_SEARCH_TOP_K', parameters('azureSearchTopK'), 'AZURE_SEARCH_ENABLE_IN_DOMAIN', parameters('azureSearchEnableInDomain'), 'AZURE_SEARCH_FILENAME_COLUMN', parameters('azureSearchFilenameColumn'), 'AZURE_SEARCH_FILTER', parameters('azureSearchFilter'), 'AZURE_SEARCH_FIELDS_ID', parameters('azureSearchFieldId'), 'AZURE_SEARCH_CONTENT_COLUMN', parameters('azureSearchContentColumn'), 'AZURE_SEARCH_CONTENT_VECTOR_COLUMN', parameters('azureSearchVectorColumn'), 'AZURE_SEARCH_TITLE_COLUMN', parameters('azureSearchTitleColumn'), 'AZURE_SEARCH_FIELDS_METADATA', parameters('azureSearchFieldsMetadata'), 'AZURE_SEARCH_SOURCE_COLUMN', parameters('azureSearchSourceColumn'), 'AZURE_SEARCH_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchTextColumn'), ''), 'AZURE_SEARCH_LAYOUT_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchLayoutTextColumn'), ''), 'AZURE_SEARCH_CHUNK_COLUMN', parameters('azureSearchChunkColumn'), 'AZURE_SEARCH_OFFSET_COLUMN', parameters('azureSearchOffsetColumn'), 'AZURE_SEARCH_URL_COLUMN', parameters('azureSearchUrlColumn'), 'AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION', parameters('azureSearchUseIntegratedVectorization')), if(equals(parameters('databaseType'), 'PostgreSQL'), createObject('AZURE_POSTGRESQL_HOST_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLServerName, 'AZURE_POSTGRESQL_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLDatabaseName, 'AZURE_POSTGRESQL_USER', parameters('websiteName')), createObject())))]"
           }
         },
         "template": {
@@ -2659,8 +2666,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "18282125486154751807"
+              "version": "0.36.177.2456",
+              "templateHash": "12289189115953002675"
             }
           },
           "parameters": {
@@ -2782,8 +2789,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "17297314312801200043"
+                      "version": "0.36.177.2456",
+                      "templateHash": "211085466725967833"
                     },
                     "description": "Creates an Azure App Service in an existing Azure App Service plan."
                   },
@@ -3009,8 +3016,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.36.1.42791",
-                              "templateHash": "8872422051335608470"
+                              "version": "0.36.177.2456",
+                              "templateHash": "2114937881746412139"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -3086,8 +3093,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -3154,8 +3161,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -3222,8 +3229,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -3290,8 +3297,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -3355,8 +3362,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "13097350302282890335"
+                      "version": "0.36.177.2456",
+                      "templateHash": "15649900872986233495"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -3430,8 +3437,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "399023243105742355"
+                      "version": "0.36.177.2456",
+                      "templateHash": "9287160422728403181"
                     },
                     "description": "Creates a SQL role assignment under an Azure Cosmos DB account."
                   },
@@ -3534,7 +3541,7 @@
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'keyvault'), '2022-09-01').outputs.name.value]"
           },
           "appSettings": {
-            "value": "[union(createObject('AZURE_BLOB_ACCOUNT_NAME', parameters('storageAccountName'), 'AZURE_BLOB_CONTAINER_NAME', variables('blobContainerName'), 'AZURE_FORM_RECOGNIZER_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('formRecognizerName')), '2022-09-01').outputs.endpoint.value, 'AZURE_COMPUTER_VISION_ENDPOINT', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.endpoint.value, ''), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_API_VERSION', parameters('computerVisionVectorizeImageApiVersion'), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_MODEL_VERSION', parameters('computerVisionVectorizeImageModelVersion'), 'AZURE_CONTENT_SAFETY_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('contentSafetyName')), '2022-09-01').outputs.endpoint.value, 'AZURE_OPENAI_RESOURCE', parameters('azureOpenAIResourceName'), 'AZURE_OPENAI_MODEL', parameters('azureOpenAIModel'), 'AZURE_OPENAI_MODEL_NAME', parameters('azureOpenAIModelName'), 'AZURE_OPENAI_MODEL_VERSION', parameters('azureOpenAIModelVersion'), 'AZURE_OPENAI_TEMPERATURE', parameters('azureOpenAITemperature'), 'AZURE_OPENAI_TOP_P', parameters('azureOpenAITopP'), 'AZURE_OPENAI_MAX_TOKENS', parameters('azureOpenAIMaxTokens'), 'AZURE_OPENAI_STOP_SEQUENCE', parameters('azureOpenAIStopSequence'), 'AZURE_OPENAI_SYSTEM_MESSAGE', parameters('azureOpenAISystemMessage'), 'AZURE_OPENAI_API_VERSION', parameters('azureOpenAIApiVersion'), 'AZURE_OPENAI_STREAM', parameters('azureOpenAIStream'), 'AZURE_OPENAI_EMBEDDING_MODEL', parameters('azureOpenAIEmbeddingModel'), 'AZURE_OPENAI_EMBEDDING_MODEL_NAME', parameters('azureOpenAIEmbeddingModelName'), 'AZURE_OPENAI_EMBEDDING_MODEL_VERSION', parameters('azureOpenAIEmbeddingModelVersion'), 'AZURE_SPEECH_SERVICE_NAME', parameters('speechServiceName'), 'AZURE_SPEECH_SERVICE_REGION', parameters('location'), 'AZURE_SPEECH_RECOGNIZER_LANGUAGES', parameters('recognizedLanguages'), 'USE_ADVANCED_IMAGE_PROCESSING', parameters('useAdvancedImageProcessing'), 'ADVANCED_IMAGE_PROCESSING_MAX_IMAGES', parameters('advancedImageProcessingMaxImages'), 'ORCHESTRATION_STRATEGY', parameters('orchestrationStrategy'), 'CONVERSATION_FLOW', parameters('conversationFlow'), 'LOGLEVEL', parameters('logLevel'), 'DATABASE_TYPE', parameters('databaseType'), 'OPEN_AI_FUNCTIONS_SYSTEM_PROMPT', variables('openAIFunctionsSystemPrompt'), 'SEMENTIC_KERNEL_SYSTEM_PROMPT', variables('semanticKernelSystemPrompt')), if(equals(parameters('databaseType'), 'CosmosDB'), createObject('AZURE_COSMOSDB_ACCOUNT_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosAccountName, 'AZURE_COSMOSDB_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosDatabaseName, 'AZURE_COSMOSDB_CONVERSATIONS_CONTAINER_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosContainerName, 'AZURE_COSMOSDB_ENABLE_FEEDBACK', true(), 'AZURE_SEARCH_USE_SEMANTIC_SEARCH', parameters('azureSearchUseSemanticSearch'), 'AZURE_SEARCH_SERVICE', format('https://{0}.search.windows.net', parameters('azureAISearchName')), 'AZURE_SEARCH_INDEX', parameters('azureSearchIndex'), 'AZURE_SEARCH_CONVERSATIONS_LOG_INDEX', parameters('azureSearchConversationLogIndex'), 'AZURE_SEARCH_SEMANTIC_SEARCH_CONFIG', parameters('azureSearchSemanticSearchConfig'), 'AZURE_SEARCH_INDEX_IS_PRECHUNKED', parameters('azureSearchIndexIsPrechunked'), 'AZURE_SEARCH_TOP_K', parameters('azureSearchTopK'), 'AZURE_SEARCH_ENABLE_IN_DOMAIN', parameters('azureSearchEnableInDomain'), 'AZURE_SEARCH_FILENAME_COLUMN', parameters('azureSearchFilenameColumn'), 'AZURE_SEARCH_FILTER', parameters('azureSearchFilter'), 'AZURE_SEARCH_FIELDS_ID', parameters('azureSearchFieldId'), 'AZURE_SEARCH_CONTENT_COLUMN', parameters('azureSearchContentColumn'), 'AZURE_SEARCH_CONTENT_VECTOR_COLUMN', parameters('azureSearchVectorColumn'), 'AZURE_SEARCH_TITLE_COLUMN', parameters('azureSearchTitleColumn'), 'AZURE_SEARCH_FIELDS_METADATA', parameters('azureSearchFieldsMetadata'), 'AZURE_SEARCH_SOURCE_COLUMN', parameters('azureSearchSourceColumn'), 'AZURE_SEARCH_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchTextColumn'), ''), 'AZURE_SEARCH_LAYOUT_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchLayoutTextColumn'), ''), 'AZURE_SEARCH_CHUNK_COLUMN', parameters('azureSearchChunkColumn'), 'AZURE_SEARCH_OFFSET_COLUMN', parameters('azureSearchOffsetColumn'), 'AZURE_SEARCH_URL_COLUMN', parameters('azureSearchUrlColumn'), 'AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION', parameters('azureSearchUseIntegratedVectorization')), if(equals(parameters('databaseType'), 'PostgreSQL'), createObject('AZURE_POSTGRESQL_HOST_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLServerName, 'AZURE_POSTGRESQL_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLDatabaseName, 'AZURE_POSTGRESQL_USER', format('{0}-docker', parameters('websiteName'))), createObject())))]"
+            "value": "[union(createObject('AZURE_BLOB_ACCOUNT_NAME', parameters('storageAccountName'), 'AZURE_BLOB_CONTAINER_NAME', variables('blobContainerName'), 'AZURE_FORM_RECOGNIZER_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('formRecognizerName')), '2022-09-01').outputs.endpoint.value, 'AZURE_COMPUTER_VISION_ENDPOINT', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.endpoint.value, ''), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_API_VERSION', parameters('computerVisionVectorizeImageApiVersion'), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_MODEL_VERSION', parameters('computerVisionVectorizeImageModelVersion'), 'AZURE_CONTENT_SAFETY_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('contentSafetyName')), '2022-09-01').outputs.endpoint.value, 'AZURE_OPENAI_RESOURCE', parameters('azureOpenAIResourceName'), 'AZURE_OPENAI_MODEL', parameters('azureOpenAIModel'), 'AZURE_OPENAI_MODEL_NAME', parameters('azureOpenAIModelName'), 'AZURE_OPENAI_MODEL_VERSION', parameters('azureOpenAIModelVersion'), 'AZURE_OPENAI_TEMPERATURE', parameters('azureOpenAITemperature'), 'AZURE_OPENAI_TOP_P', parameters('azureOpenAITopP'), 'AZURE_OPENAI_MAX_TOKENS', parameters('azureOpenAIMaxTokens'), 'AZURE_OPENAI_STOP_SEQUENCE', parameters('azureOpenAIStopSequence'), 'AZURE_OPENAI_SYSTEM_MESSAGE', parameters('azureOpenAISystemMessage'), 'AZURE_OPENAI_API_VERSION', parameters('azureOpenAIApiVersion'), 'AZURE_OPENAI_STREAM', parameters('azureOpenAIStream'), 'AZURE_OPENAI_EMBEDDING_MODEL', parameters('azureOpenAIEmbeddingModel'), 'AZURE_OPENAI_EMBEDDING_MODEL_NAME', parameters('azureOpenAIEmbeddingModelName'), 'AZURE_OPENAI_EMBEDDING_MODEL_VERSION', parameters('azureOpenAIEmbeddingModelVersion'), 'AZURE_SPEECH_SERVICE_NAME', parameters('speechServiceName'), 'AZURE_SPEECH_SERVICE_REGION', parameters('location'), 'AZURE_SPEECH_RECOGNIZER_LANGUAGES', parameters('recognizedLanguages'), 'USE_ADVANCED_IMAGE_PROCESSING', parameters('useAdvancedImageProcessing'), 'ADVANCED_IMAGE_PROCESSING_MAX_IMAGES', parameters('advancedImageProcessingMaxImages'), 'ORCHESTRATION_STRATEGY', parameters('orchestrationStrategy'), 'CONVERSATION_FLOW', parameters('conversationFlow'), 'LOGLEVEL', parameters('logLevel'), 'DATABASE_TYPE', parameters('databaseType'), 'OPEN_AI_FUNCTIONS_SYSTEM_PROMPT', variables('openAIFunctionsSystemPrompt'), 'SEMANTIC_KERNEL_SYSTEM_PROMPT', variables('semanticKernelSystemPrompt'), 'APP_ENV', parameters('appEnvironment')), if(equals(parameters('databaseType'), 'CosmosDB'), createObject('AZURE_COSMOSDB_ACCOUNT_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosAccountName, 'AZURE_COSMOSDB_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosDatabaseName, 'AZURE_COSMOSDB_CONVERSATIONS_CONTAINER_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosOutput.value.cosmosContainerName, 'AZURE_COSMOSDB_ENABLE_FEEDBACK', true(), 'AZURE_SEARCH_USE_SEMANTIC_SEARCH', parameters('azureSearchUseSemanticSearch'), 'AZURE_SEARCH_SERVICE', format('https://{0}.search.windows.net', parameters('azureAISearchName')), 'AZURE_SEARCH_INDEX', parameters('azureSearchIndex'), 'AZURE_SEARCH_CONVERSATIONS_LOG_INDEX', parameters('azureSearchConversationLogIndex'), 'AZURE_SEARCH_SEMANTIC_SEARCH_CONFIG', parameters('azureSearchSemanticSearchConfig'), 'AZURE_SEARCH_INDEX_IS_PRECHUNKED', parameters('azureSearchIndexIsPrechunked'), 'AZURE_SEARCH_TOP_K', parameters('azureSearchTopK'), 'AZURE_SEARCH_ENABLE_IN_DOMAIN', parameters('azureSearchEnableInDomain'), 'AZURE_SEARCH_FILENAME_COLUMN', parameters('azureSearchFilenameColumn'), 'AZURE_SEARCH_FILTER', parameters('azureSearchFilter'), 'AZURE_SEARCH_FIELDS_ID', parameters('azureSearchFieldId'), 'AZURE_SEARCH_CONTENT_COLUMN', parameters('azureSearchContentColumn'), 'AZURE_SEARCH_CONTENT_VECTOR_COLUMN', parameters('azureSearchVectorColumn'), 'AZURE_SEARCH_TITLE_COLUMN', parameters('azureSearchTitleColumn'), 'AZURE_SEARCH_FIELDS_METADATA', parameters('azureSearchFieldsMetadata'), 'AZURE_SEARCH_SOURCE_COLUMN', parameters('azureSearchSourceColumn'), 'AZURE_SEARCH_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchTextColumn'), ''), 'AZURE_SEARCH_LAYOUT_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchLayoutTextColumn'), ''), 'AZURE_SEARCH_CHUNK_COLUMN', parameters('azureSearchChunkColumn'), 'AZURE_SEARCH_OFFSET_COLUMN', parameters('azureSearchOffsetColumn'), 'AZURE_SEARCH_URL_COLUMN', parameters('azureSearchUrlColumn'), 'AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION', parameters('azureSearchUseIntegratedVectorization')), if(equals(parameters('databaseType'), 'PostgreSQL'), createObject('AZURE_POSTGRESQL_HOST_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLServerName, 'AZURE_POSTGRESQL_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLDatabaseName, 'AZURE_POSTGRESQL_USER', format('{0}-docker', parameters('websiteName'))), createObject())))]"
           }
         },
         "template": {
@@ -3543,8 +3550,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "18282125486154751807"
+              "version": "0.36.177.2456",
+              "templateHash": "12289189115953002675"
             }
           },
           "parameters": {
@@ -3666,8 +3673,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "17297314312801200043"
+                      "version": "0.36.177.2456",
+                      "templateHash": "211085466725967833"
                     },
                     "description": "Creates an Azure App Service in an existing Azure App Service plan."
                   },
@@ -3893,8 +3900,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.36.1.42791",
-                              "templateHash": "8872422051335608470"
+                              "version": "0.36.177.2456",
+                              "templateHash": "2114937881746412139"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -3970,8 +3977,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -4038,8 +4045,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -4106,8 +4113,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -4174,8 +4181,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -4239,8 +4246,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "13097350302282890335"
+                      "version": "0.36.177.2456",
+                      "templateHash": "15649900872986233495"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -4314,8 +4321,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "399023243105742355"
+                      "version": "0.36.177.2456",
+                      "templateHash": "9287160422728403181"
                     },
                     "description": "Creates a SQL role assignment under an Azure Cosmos DB account."
                   },
@@ -4415,7 +4422,7 @@
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'keyvault'), '2022-09-01').outputs.name.value]"
           },
           "appSettings": {
-            "value": "[union(createObject('AZURE_BLOB_ACCOUNT_NAME', parameters('storageAccountName'), 'AZURE_BLOB_CONTAINER_NAME', variables('blobContainerName'), 'AZURE_FORM_RECOGNIZER_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('formRecognizerName')), '2022-09-01').outputs.endpoint.value, 'AZURE_COMPUTER_VISION_ENDPOINT', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.endpoint.value, ''), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_API_VERSION', parameters('computerVisionVectorizeImageApiVersion'), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_MODEL_VERSION', parameters('computerVisionVectorizeImageModelVersion'), 'AZURE_CONTENT_SAFETY_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('contentSafetyName')), '2022-09-01').outputs.endpoint.value, 'AZURE_OPENAI_RESOURCE', parameters('azureOpenAIResourceName'), 'AZURE_OPENAI_MODEL', parameters('azureOpenAIModel'), 'AZURE_OPENAI_MODEL_NAME', parameters('azureOpenAIModelName'), 'AZURE_OPENAI_MODEL_VERSION', parameters('azureOpenAIModelVersion'), 'AZURE_OPENAI_TEMPERATURE', parameters('azureOpenAITemperature'), 'AZURE_OPENAI_TOP_P', parameters('azureOpenAITopP'), 'AZURE_OPENAI_MAX_TOKENS', parameters('azureOpenAIMaxTokens'), 'AZURE_OPENAI_STOP_SEQUENCE', parameters('azureOpenAIStopSequence'), 'AZURE_OPENAI_SYSTEM_MESSAGE', parameters('azureOpenAISystemMessage'), 'AZURE_OPENAI_API_VERSION', parameters('azureOpenAIApiVersion'), 'AZURE_OPENAI_STREAM', parameters('azureOpenAIStream'), 'AZURE_OPENAI_EMBEDDING_MODEL', parameters('azureOpenAIEmbeddingModel'), 'AZURE_OPENAI_EMBEDDING_MODEL_NAME', parameters('azureOpenAIEmbeddingModelName'), 'AZURE_OPENAI_EMBEDDING_MODEL_VERSION', parameters('azureOpenAIEmbeddingModelVersion'), 'USE_ADVANCED_IMAGE_PROCESSING', parameters('useAdvancedImageProcessing'), 'BACKEND_URL', format('https://{0}.azurewebsites.net', parameters('functionName')), 'DOCUMENT_PROCESSING_QUEUE_NAME', variables('queueName'), 'FUNCTION_KEY', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'storekeys'), '2022-09-01').outputs.FUNCTION_KEY.value, 'ORCHESTRATION_STRATEGY', parameters('orchestrationStrategy'), 'CONVERSATION_FLOW', parameters('conversationFlow'), 'LOGLEVEL', parameters('logLevel'), 'DATABASE_TYPE', parameters('databaseType'), 'USE_KEY_VAULT', 'true'), if(equals(parameters('databaseType'), 'CosmosDB'), createObject('AZURE_SEARCH_SERVICE', format('https://{0}.search.windows.net', parameters('azureAISearchName')), 'AZURE_SEARCH_INDEX', parameters('azureSearchIndex'), 'AZURE_SEARCH_USE_SEMANTIC_SEARCH', parameters('azureSearchUseSemanticSearch'), 'AZURE_SEARCH_SEMANTIC_SEARCH_CONFIG', parameters('azureSearchSemanticSearchConfig'), 'AZURE_SEARCH_INDEX_IS_PRECHUNKED', parameters('azureSearchIndexIsPrechunked'), 'AZURE_SEARCH_TOP_K', parameters('azureSearchTopK'), 'AZURE_SEARCH_ENABLE_IN_DOMAIN', parameters('azureSearchEnableInDomain'), 'AZURE_SEARCH_FILENAME_COLUMN', parameters('azureSearchFilenameColumn'), 'AZURE_SEARCH_FILTER', parameters('azureSearchFilter'), 'AZURE_SEARCH_FIELDS_ID', parameters('azureSearchFieldId'), 'AZURE_SEARCH_CONTENT_COLUMN', parameters('azureSearchContentColumn'), 'AZURE_SEARCH_CONTENT_VECTOR_COLUMN', parameters('azureSearchVectorColumn'), 'AZURE_SEARCH_TITLE_COLUMN', parameters('azureSearchTitleColumn'), 'AZURE_SEARCH_FIELDS_METADATA', parameters('azureSearchFieldsMetadata'), 'AZURE_SEARCH_SOURCE_COLUMN', parameters('azureSearchSourceColumn'), 'AZURE_SEARCH_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchTextColumn'), ''), 'AZURE_SEARCH_LAYOUT_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchLayoutTextColumn'), ''), 'AZURE_SEARCH_CHUNK_COLUMN', parameters('azureSearchChunkColumn'), 'AZURE_SEARCH_OFFSET_COLUMN', parameters('azureSearchOffsetColumn'), 'AZURE_SEARCH_URL_COLUMN', parameters('azureSearchUrlColumn'), 'AZURE_SEARCH_DATASOURCE_NAME', parameters('azureSearchDatasource'), 'AZURE_SEARCH_INDEXER_NAME', parameters('azureSearchIndexer'), 'AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION', parameters('azureSearchUseIntegratedVectorization')), if(equals(parameters('databaseType'), 'PostgreSQL'), createObject('AZURE_POSTGRESQL_HOST_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLServerName, 'AZURE_POSTGRESQL_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLDatabaseName, 'AZURE_POSTGRESQL_USER', parameters('adminWebsiteName')), createObject())))]"
+            "value": "[union(createObject('AZURE_BLOB_ACCOUNT_NAME', parameters('storageAccountName'), 'AZURE_BLOB_CONTAINER_NAME', variables('blobContainerName'), 'AZURE_FORM_RECOGNIZER_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('formRecognizerName')), '2022-09-01').outputs.endpoint.value, 'AZURE_COMPUTER_VISION_ENDPOINT', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.endpoint.value, ''), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_API_VERSION', parameters('computerVisionVectorizeImageApiVersion'), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_MODEL_VERSION', parameters('computerVisionVectorizeImageModelVersion'), 'AZURE_CONTENT_SAFETY_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('contentSafetyName')), '2022-09-01').outputs.endpoint.value, 'AZURE_OPENAI_RESOURCE', parameters('azureOpenAIResourceName'), 'AZURE_OPENAI_MODEL', parameters('azureOpenAIModel'), 'AZURE_OPENAI_MODEL_NAME', parameters('azureOpenAIModelName'), 'AZURE_OPENAI_MODEL_VERSION', parameters('azureOpenAIModelVersion'), 'AZURE_OPENAI_TEMPERATURE', parameters('azureOpenAITemperature'), 'AZURE_OPENAI_TOP_P', parameters('azureOpenAITopP'), 'AZURE_OPENAI_MAX_TOKENS', parameters('azureOpenAIMaxTokens'), 'AZURE_OPENAI_STOP_SEQUENCE', parameters('azureOpenAIStopSequence'), 'AZURE_OPENAI_SYSTEM_MESSAGE', parameters('azureOpenAISystemMessage'), 'AZURE_OPENAI_API_VERSION', parameters('azureOpenAIApiVersion'), 'AZURE_OPENAI_STREAM', parameters('azureOpenAIStream'), 'AZURE_OPENAI_EMBEDDING_MODEL', parameters('azureOpenAIEmbeddingModel'), 'AZURE_OPENAI_EMBEDDING_MODEL_NAME', parameters('azureOpenAIEmbeddingModelName'), 'AZURE_OPENAI_EMBEDDING_MODEL_VERSION', parameters('azureOpenAIEmbeddingModelVersion'), 'USE_ADVANCED_IMAGE_PROCESSING', parameters('useAdvancedImageProcessing'), 'BACKEND_URL', format('https://{0}.azurewebsites.net', parameters('functionName')), 'DOCUMENT_PROCESSING_QUEUE_NAME', variables('queueName'), 'FUNCTION_KEY', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'storekeys'), '2022-09-01').outputs.FUNCTION_KEY.value, 'ORCHESTRATION_STRATEGY', parameters('orchestrationStrategy'), 'CONVERSATION_FLOW', parameters('conversationFlow'), 'LOGLEVEL', parameters('logLevel'), 'DATABASE_TYPE', parameters('databaseType'), 'USE_KEY_VAULT', 'true', 'APP_ENV', parameters('appEnvironment')), if(equals(parameters('databaseType'), 'CosmosDB'), createObject('AZURE_SEARCH_SERVICE', format('https://{0}.search.windows.net', parameters('azureAISearchName')), 'AZURE_SEARCH_INDEX', parameters('azureSearchIndex'), 'AZURE_SEARCH_USE_SEMANTIC_SEARCH', parameters('azureSearchUseSemanticSearch'), 'AZURE_SEARCH_SEMANTIC_SEARCH_CONFIG', parameters('azureSearchSemanticSearchConfig'), 'AZURE_SEARCH_INDEX_IS_PRECHUNKED', parameters('azureSearchIndexIsPrechunked'), 'AZURE_SEARCH_TOP_K', parameters('azureSearchTopK'), 'AZURE_SEARCH_ENABLE_IN_DOMAIN', parameters('azureSearchEnableInDomain'), 'AZURE_SEARCH_FILENAME_COLUMN', parameters('azureSearchFilenameColumn'), 'AZURE_SEARCH_FILTER', parameters('azureSearchFilter'), 'AZURE_SEARCH_FIELDS_ID', parameters('azureSearchFieldId'), 'AZURE_SEARCH_CONTENT_COLUMN', parameters('azureSearchContentColumn'), 'AZURE_SEARCH_CONTENT_VECTOR_COLUMN', parameters('azureSearchVectorColumn'), 'AZURE_SEARCH_TITLE_COLUMN', parameters('azureSearchTitleColumn'), 'AZURE_SEARCH_FIELDS_METADATA', parameters('azureSearchFieldsMetadata'), 'AZURE_SEARCH_SOURCE_COLUMN', parameters('azureSearchSourceColumn'), 'AZURE_SEARCH_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchTextColumn'), ''), 'AZURE_SEARCH_LAYOUT_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchLayoutTextColumn'), ''), 'AZURE_SEARCH_CHUNK_COLUMN', parameters('azureSearchChunkColumn'), 'AZURE_SEARCH_OFFSET_COLUMN', parameters('azureSearchOffsetColumn'), 'AZURE_SEARCH_URL_COLUMN', parameters('azureSearchUrlColumn'), 'AZURE_SEARCH_DATASOURCE_NAME', parameters('azureSearchDatasource'), 'AZURE_SEARCH_INDEXER_NAME', parameters('azureSearchIndexer'), 'AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION', parameters('azureSearchUseIntegratedVectorization')), if(equals(parameters('databaseType'), 'PostgreSQL'), createObject('AZURE_POSTGRESQL_HOST_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLServerName, 'AZURE_POSTGRESQL_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLDatabaseName, 'AZURE_POSTGRESQL_USER', parameters('adminWebsiteName')), createObject())))]"
           }
         },
         "template": {
@@ -4424,8 +4431,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "1039793222387015566"
+              "version": "0.36.177.2456",
+              "templateHash": "8774273653213345889"
             }
           },
           "parameters": {
@@ -4536,8 +4543,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "17297314312801200043"
+                      "version": "0.36.177.2456",
+                      "templateHash": "211085466725967833"
                     },
                     "description": "Creates an Azure App Service in an existing Azure App Service plan."
                   },
@@ -4763,8 +4770,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.36.1.42791",
-                              "templateHash": "8872422051335608470"
+                              "version": "0.36.177.2456",
+                              "templateHash": "2114937881746412139"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -4840,8 +4847,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -4908,8 +4915,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -4976,8 +4983,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -5044,8 +5051,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -5109,8 +5116,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "13097350302282890335"
+                      "version": "0.36.177.2456",
+                      "templateHash": "15649900872986233495"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -5220,7 +5227,7 @@
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'keyvault'), '2022-09-01').outputs.name.value]"
           },
           "appSettings": {
-            "value": "[union(createObject('AZURE_BLOB_ACCOUNT_NAME', parameters('storageAccountName'), 'AZURE_BLOB_CONTAINER_NAME', variables('blobContainerName'), 'AZURE_FORM_RECOGNIZER_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('formRecognizerName')), '2022-09-01').outputs.endpoint.value, 'AZURE_COMPUTER_VISION_ENDPOINT', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.endpoint.value, ''), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_API_VERSION', parameters('computerVisionVectorizeImageApiVersion'), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_MODEL_VERSION', parameters('computerVisionVectorizeImageModelVersion'), 'AZURE_CONTENT_SAFETY_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('contentSafetyName')), '2022-09-01').outputs.endpoint.value, 'AZURE_OPENAI_RESOURCE', parameters('azureOpenAIResourceName'), 'AZURE_OPENAI_MODEL', parameters('azureOpenAIModel'), 'AZURE_OPENAI_MODEL_NAME', parameters('azureOpenAIModelName'), 'AZURE_OPENAI_MODEL_VERSION', parameters('azureOpenAIModelVersion'), 'AZURE_OPENAI_TEMPERATURE', parameters('azureOpenAITemperature'), 'AZURE_OPENAI_TOP_P', parameters('azureOpenAITopP'), 'AZURE_OPENAI_MAX_TOKENS', parameters('azureOpenAIMaxTokens'), 'AZURE_OPENAI_STOP_SEQUENCE', parameters('azureOpenAIStopSequence'), 'AZURE_OPENAI_SYSTEM_MESSAGE', parameters('azureOpenAISystemMessage'), 'AZURE_OPENAI_API_VERSION', parameters('azureOpenAIApiVersion'), 'AZURE_OPENAI_STREAM', parameters('azureOpenAIStream'), 'AZURE_OPENAI_EMBEDDING_MODEL', parameters('azureOpenAIEmbeddingModel'), 'AZURE_OPENAI_EMBEDDING_MODEL_NAME', parameters('azureOpenAIEmbeddingModelName'), 'AZURE_OPENAI_EMBEDDING_MODEL_VERSION', parameters('azureOpenAIEmbeddingModelVersion'), 'USE_ADVANCED_IMAGE_PROCESSING', parameters('useAdvancedImageProcessing'), 'BACKEND_URL', format('https://{0}-docker.azurewebsites.net', parameters('functionName')), 'DOCUMENT_PROCESSING_QUEUE_NAME', variables('queueName'), 'FUNCTION_KEY', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'storekeys'), '2022-09-01').outputs.FUNCTION_KEY.value, 'ORCHESTRATION_STRATEGY', parameters('orchestrationStrategy'), 'CONVERSATION_FLOW', parameters('conversationFlow'), 'LOGLEVEL', parameters('logLevel'), 'DATABASE_TYPE', parameters('databaseType'), 'USE_KEY_VAULT', 'true'), if(equals(parameters('databaseType'), 'CosmosDB'), createObject('AZURE_SEARCH_SERVICE', format('https://{0}.search.windows.net', parameters('azureAISearchName')), 'AZURE_SEARCH_INDEX', parameters('azureSearchIndex'), 'AZURE_SEARCH_USE_SEMANTIC_SEARCH', parameters('azureSearchUseSemanticSearch'), 'AZURE_SEARCH_SEMANTIC_SEARCH_CONFIG', parameters('azureSearchSemanticSearchConfig'), 'AZURE_SEARCH_INDEX_IS_PRECHUNKED', parameters('azureSearchIndexIsPrechunked'), 'AZURE_SEARCH_TOP_K', parameters('azureSearchTopK'), 'AZURE_SEARCH_ENABLE_IN_DOMAIN', parameters('azureSearchEnableInDomain'), 'AZURE_SEARCH_FILENAME_COLUMN', parameters('azureSearchFilenameColumn'), 'AZURE_SEARCH_FILTER', parameters('azureSearchFilter'), 'AZURE_SEARCH_FIELDS_ID', parameters('azureSearchFieldId'), 'AZURE_SEARCH_CONTENT_COLUMN', parameters('azureSearchContentColumn'), 'AZURE_SEARCH_CONTENT_VECTOR_COLUMN', parameters('azureSearchVectorColumn'), 'AZURE_SEARCH_TITLE_COLUMN', parameters('azureSearchTitleColumn'), 'AZURE_SEARCH_FIELDS_METADATA', parameters('azureSearchFieldsMetadata'), 'AZURE_SEARCH_SOURCE_COLUMN', parameters('azureSearchSourceColumn'), 'AZURE_SEARCH_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchTextColumn'), ''), 'AZURE_SEARCH_LAYOUT_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchLayoutTextColumn'), ''), 'AZURE_SEARCH_CHUNK_COLUMN', parameters('azureSearchChunkColumn'), 'AZURE_SEARCH_OFFSET_COLUMN', parameters('azureSearchOffsetColumn'), 'AZURE_SEARCH_URL_COLUMN', parameters('azureSearchUrlColumn'), 'AZURE_SEARCH_DATASOURCE_NAME', parameters('azureSearchDatasource'), 'AZURE_SEARCH_INDEXER_NAME', parameters('azureSearchIndexer'), 'AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION', parameters('azureSearchUseIntegratedVectorization')), if(equals(parameters('databaseType'), 'PostgreSQL'), createObject('AZURE_POSTGRESQL_HOST_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLServerName, 'AZURE_POSTGRESQL_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLDatabaseName, 'AZURE_POSTGRESQL_USER', format('{0}-docker', parameters('adminWebsiteName'))), createObject())))]"
+            "value": "[union(createObject('AZURE_BLOB_ACCOUNT_NAME', parameters('storageAccountName'), 'AZURE_BLOB_CONTAINER_NAME', variables('blobContainerName'), 'AZURE_FORM_RECOGNIZER_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('formRecognizerName')), '2022-09-01').outputs.endpoint.value, 'AZURE_COMPUTER_VISION_ENDPOINT', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.endpoint.value, ''), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_API_VERSION', parameters('computerVisionVectorizeImageApiVersion'), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_MODEL_VERSION', parameters('computerVisionVectorizeImageModelVersion'), 'AZURE_CONTENT_SAFETY_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('contentSafetyName')), '2022-09-01').outputs.endpoint.value, 'AZURE_OPENAI_RESOURCE', parameters('azureOpenAIResourceName'), 'AZURE_OPENAI_MODEL', parameters('azureOpenAIModel'), 'AZURE_OPENAI_MODEL_NAME', parameters('azureOpenAIModelName'), 'AZURE_OPENAI_MODEL_VERSION', parameters('azureOpenAIModelVersion'), 'AZURE_OPENAI_TEMPERATURE', parameters('azureOpenAITemperature'), 'AZURE_OPENAI_TOP_P', parameters('azureOpenAITopP'), 'AZURE_OPENAI_MAX_TOKENS', parameters('azureOpenAIMaxTokens'), 'AZURE_OPENAI_STOP_SEQUENCE', parameters('azureOpenAIStopSequence'), 'AZURE_OPENAI_SYSTEM_MESSAGE', parameters('azureOpenAISystemMessage'), 'AZURE_OPENAI_API_VERSION', parameters('azureOpenAIApiVersion'), 'AZURE_OPENAI_STREAM', parameters('azureOpenAIStream'), 'AZURE_OPENAI_EMBEDDING_MODEL', parameters('azureOpenAIEmbeddingModel'), 'AZURE_OPENAI_EMBEDDING_MODEL_NAME', parameters('azureOpenAIEmbeddingModelName'), 'AZURE_OPENAI_EMBEDDING_MODEL_VERSION', parameters('azureOpenAIEmbeddingModelVersion'), 'USE_ADVANCED_IMAGE_PROCESSING', parameters('useAdvancedImageProcessing'), 'BACKEND_URL', format('https://{0}-docker.azurewebsites.net', parameters('functionName')), 'DOCUMENT_PROCESSING_QUEUE_NAME', variables('queueName'), 'FUNCTION_KEY', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'storekeys'), '2022-09-01').outputs.FUNCTION_KEY.value, 'ORCHESTRATION_STRATEGY', parameters('orchestrationStrategy'), 'CONVERSATION_FLOW', parameters('conversationFlow'), 'LOGLEVEL', parameters('logLevel'), 'DATABASE_TYPE', parameters('databaseType'), 'USE_KEY_VAULT', 'true', 'APP_ENV', parameters('appEnvironment')), if(equals(parameters('databaseType'), 'CosmosDB'), createObject('AZURE_SEARCH_SERVICE', format('https://{0}.search.windows.net', parameters('azureAISearchName')), 'AZURE_SEARCH_INDEX', parameters('azureSearchIndex'), 'AZURE_SEARCH_USE_SEMANTIC_SEARCH', parameters('azureSearchUseSemanticSearch'), 'AZURE_SEARCH_SEMANTIC_SEARCH_CONFIG', parameters('azureSearchSemanticSearchConfig'), 'AZURE_SEARCH_INDEX_IS_PRECHUNKED', parameters('azureSearchIndexIsPrechunked'), 'AZURE_SEARCH_TOP_K', parameters('azureSearchTopK'), 'AZURE_SEARCH_ENABLE_IN_DOMAIN', parameters('azureSearchEnableInDomain'), 'AZURE_SEARCH_FILENAME_COLUMN', parameters('azureSearchFilenameColumn'), 'AZURE_SEARCH_FILTER', parameters('azureSearchFilter'), 'AZURE_SEARCH_FIELDS_ID', parameters('azureSearchFieldId'), 'AZURE_SEARCH_CONTENT_COLUMN', parameters('azureSearchContentColumn'), 'AZURE_SEARCH_CONTENT_VECTOR_COLUMN', parameters('azureSearchVectorColumn'), 'AZURE_SEARCH_TITLE_COLUMN', parameters('azureSearchTitleColumn'), 'AZURE_SEARCH_FIELDS_METADATA', parameters('azureSearchFieldsMetadata'), 'AZURE_SEARCH_SOURCE_COLUMN', parameters('azureSearchSourceColumn'), 'AZURE_SEARCH_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchTextColumn'), ''), 'AZURE_SEARCH_LAYOUT_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchLayoutTextColumn'), ''), 'AZURE_SEARCH_CHUNK_COLUMN', parameters('azureSearchChunkColumn'), 'AZURE_SEARCH_OFFSET_COLUMN', parameters('azureSearchOffsetColumn'), 'AZURE_SEARCH_URL_COLUMN', parameters('azureSearchUrlColumn'), 'AZURE_SEARCH_DATASOURCE_NAME', parameters('azureSearchDatasource'), 'AZURE_SEARCH_INDEXER_NAME', parameters('azureSearchIndexer'), 'AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION', parameters('azureSearchUseIntegratedVectorization')), if(equals(parameters('databaseType'), 'PostgreSQL'), createObject('AZURE_POSTGRESQL_HOST_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLServerName, 'AZURE_POSTGRESQL_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLDatabaseName, 'AZURE_POSTGRESQL_USER', format('{0}-docker', parameters('adminWebsiteName'))), createObject())))]"
           }
         },
         "template": {
@@ -5229,8 +5236,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "1039793222387015566"
+              "version": "0.36.177.2456",
+              "templateHash": "8774273653213345889"
             }
           },
           "parameters": {
@@ -5341,8 +5348,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "17297314312801200043"
+                      "version": "0.36.177.2456",
+                      "templateHash": "211085466725967833"
                     },
                     "description": "Creates an Azure App Service in an existing Azure App Service plan."
                   },
@@ -5568,8 +5575,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.36.1.42791",
-                              "templateHash": "8872422051335608470"
+                              "version": "0.36.177.2456",
+                              "templateHash": "2114937881746412139"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -5645,8 +5652,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -5713,8 +5720,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -5781,8 +5788,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -5849,8 +5856,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -5914,8 +5921,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "13097350302282890335"
+                      "version": "0.36.177.2456",
+                      "templateHash": "15649900872986233495"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -6029,8 +6036,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "3170567318042083360"
+              "version": "0.36.177.2456",
+              "templateHash": "16408332100626942691"
             },
             "description": "Creates an Application Insights instance and a Log Analytics workspace."
           },
@@ -6088,8 +6095,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "18046713010447151328"
+                      "version": "0.36.177.2456",
+                      "templateHash": "9147911423401029465"
                     },
                     "description": "Creates a Log Analytics workspace."
                   },
@@ -6180,8 +6187,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "9396713012578391259"
+                      "version": "0.36.177.2456",
+                      "templateHash": "2629382887193957945"
                     },
                     "description": "Creates an Application Insights instance based on an existing Log Analytics workspace."
                   },
@@ -6245,8 +6252,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.36.1.42791",
-                              "templateHash": "4772814496944658769"
+                              "version": "0.36.177.2456",
+                              "templateHash": "18292703974674172388"
                             },
                             "description": "Creates a dashboard for an Application Insights instance."
                           },
@@ -7582,8 +7589,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "14423036048920164527"
+              "version": "0.36.177.2456",
+              "templateHash": "1827052244678670127"
             }
           },
           "parameters": {
@@ -7665,8 +7672,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "14924009146925222912"
+                      "version": "0.36.177.2456",
+                      "templateHash": "16459689312294949684"
                     }
                   },
                   "parameters": {
@@ -7794,7 +7801,7 @@
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'keyvault'), '2022-09-01').outputs.name.value]"
           },
           "appSettings": {
-            "value": "[union(createObject('AZURE_BLOB_ACCOUNT_NAME', parameters('storageAccountName'), 'AZURE_BLOB_CONTAINER_NAME', variables('blobContainerName'), 'AZURE_FORM_RECOGNIZER_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('formRecognizerName')), '2022-09-01').outputs.endpoint.value, 'AZURE_COMPUTER_VISION_ENDPOINT', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.endpoint.value, ''), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_API_VERSION', parameters('computerVisionVectorizeImageApiVersion'), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_MODEL_VERSION', parameters('computerVisionVectorizeImageModelVersion'), 'AZURE_CONTENT_SAFETY_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('contentSafetyName')), '2022-09-01').outputs.endpoint.value, 'AZURE_OPENAI_MODEL', parameters('azureOpenAIModel'), 'AZURE_OPENAI_MODEL_NAME', parameters('azureOpenAIModelName'), 'AZURE_OPENAI_MODEL_VERSION', parameters('azureOpenAIModelVersion'), 'AZURE_OPENAI_EMBEDDING_MODEL', parameters('azureOpenAIEmbeddingModel'), 'AZURE_OPENAI_EMBEDDING_MODEL_NAME', parameters('azureOpenAIEmbeddingModelName'), 'AZURE_OPENAI_EMBEDDING_MODEL_VERSION', parameters('azureOpenAIEmbeddingModelVersion'), 'AZURE_OPENAI_RESOURCE', parameters('azureOpenAIResourceName'), 'AZURE_OPENAI_API_VERSION', parameters('azureOpenAIApiVersion'), 'USE_ADVANCED_IMAGE_PROCESSING', parameters('useAdvancedImageProcessing'), 'DOCUMENT_PROCESSING_QUEUE_NAME', variables('queueName'), 'ORCHESTRATION_STRATEGY', parameters('orchestrationStrategy'), 'LOGLEVEL', parameters('logLevel'), 'AZURE_OPENAI_SYSTEM_MESSAGE', parameters('azureOpenAISystemMessage'), 'DATABASE_TYPE', parameters('databaseType')), if(equals(parameters('databaseType'), 'CosmosDB'), createObject('AZURE_SEARCH_INDEX', parameters('azureSearchIndex'), 'AZURE_SEARCH_SERVICE', format('https://{0}.search.windows.net', parameters('azureAISearchName')), 'AZURE_SEARCH_DATASOURCE_NAME', parameters('azureSearchDatasource'), 'AZURE_SEARCH_INDEXER_NAME', parameters('azureSearchIndexer'), 'AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION', parameters('azureSearchUseIntegratedVectorization'), 'AZURE_SEARCH_FIELDS_ID', parameters('azureSearchFieldId'), 'AZURE_SEARCH_CONTENT_COLUMN', parameters('azureSearchContentColumn'), 'AZURE_SEARCH_CONTENT_VECTOR_COLUMN', parameters('azureSearchVectorColumn'), 'AZURE_SEARCH_TITLE_COLUMN', parameters('azureSearchTitleColumn'), 'AZURE_SEARCH_FIELDS_METADATA', parameters('azureSearchFieldsMetadata'), 'AZURE_SEARCH_SOURCE_COLUMN', parameters('azureSearchSourceColumn'), 'AZURE_SEARCH_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchTextColumn'), ''), 'AZURE_SEARCH_LAYOUT_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchLayoutTextColumn'), ''), 'AZURE_SEARCH_CHUNK_COLUMN', parameters('azureSearchChunkColumn'), 'AZURE_SEARCH_OFFSET_COLUMN', parameters('azureSearchOffsetColumn'), 'AZURE_SEARCH_TOP_K', parameters('azureSearchTopK')), if(equals(parameters('databaseType'), 'PostgreSQL'), createObject('AZURE_POSTGRESQL_HOST_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLServerName, 'AZURE_POSTGRESQL_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLDatabaseName, 'AZURE_POSTGRESQL_USER', parameters('functionName')), createObject())))]"
+            "value": "[union(createObject('AZURE_BLOB_ACCOUNT_NAME', parameters('storageAccountName'), 'AZURE_BLOB_CONTAINER_NAME', variables('blobContainerName'), 'AZURE_FORM_RECOGNIZER_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('formRecognizerName')), '2022-09-01').outputs.endpoint.value, 'AZURE_COMPUTER_VISION_ENDPOINT', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.endpoint.value, ''), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_API_VERSION', parameters('computerVisionVectorizeImageApiVersion'), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_MODEL_VERSION', parameters('computerVisionVectorizeImageModelVersion'), 'AZURE_CONTENT_SAFETY_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('contentSafetyName')), '2022-09-01').outputs.endpoint.value, 'AZURE_OPENAI_MODEL', parameters('azureOpenAIModel'), 'AZURE_OPENAI_MODEL_NAME', parameters('azureOpenAIModelName'), 'AZURE_OPENAI_MODEL_VERSION', parameters('azureOpenAIModelVersion'), 'AZURE_OPENAI_EMBEDDING_MODEL', parameters('azureOpenAIEmbeddingModel'), 'AZURE_OPENAI_EMBEDDING_MODEL_NAME', parameters('azureOpenAIEmbeddingModelName'), 'AZURE_OPENAI_EMBEDDING_MODEL_VERSION', parameters('azureOpenAIEmbeddingModelVersion'), 'AZURE_OPENAI_RESOURCE', parameters('azureOpenAIResourceName'), 'AZURE_OPENAI_API_VERSION', parameters('azureOpenAIApiVersion'), 'USE_ADVANCED_IMAGE_PROCESSING', parameters('useAdvancedImageProcessing'), 'DOCUMENT_PROCESSING_QUEUE_NAME', variables('queueName'), 'ORCHESTRATION_STRATEGY', parameters('orchestrationStrategy'), 'LOGLEVEL', parameters('logLevel'), 'AZURE_OPENAI_SYSTEM_MESSAGE', parameters('azureOpenAISystemMessage'), 'DATABASE_TYPE', parameters('databaseType'), 'APP_ENV', parameters('appEnvironment')), if(equals(parameters('databaseType'), 'CosmosDB'), createObject('AZURE_SEARCH_INDEX', parameters('azureSearchIndex'), 'AZURE_SEARCH_SERVICE', format('https://{0}.search.windows.net', parameters('azureAISearchName')), 'AZURE_SEARCH_DATASOURCE_NAME', parameters('azureSearchDatasource'), 'AZURE_SEARCH_INDEXER_NAME', parameters('azureSearchIndexer'), 'AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION', parameters('azureSearchUseIntegratedVectorization'), 'AZURE_SEARCH_FIELDS_ID', parameters('azureSearchFieldId'), 'AZURE_SEARCH_CONTENT_COLUMN', parameters('azureSearchContentColumn'), 'AZURE_SEARCH_CONTENT_VECTOR_COLUMN', parameters('azureSearchVectorColumn'), 'AZURE_SEARCH_TITLE_COLUMN', parameters('azureSearchTitleColumn'), 'AZURE_SEARCH_FIELDS_METADATA', parameters('azureSearchFieldsMetadata'), 'AZURE_SEARCH_SOURCE_COLUMN', parameters('azureSearchSourceColumn'), 'AZURE_SEARCH_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchTextColumn'), ''), 'AZURE_SEARCH_LAYOUT_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchLayoutTextColumn'), ''), 'AZURE_SEARCH_CHUNK_COLUMN', parameters('azureSearchChunkColumn'), 'AZURE_SEARCH_OFFSET_COLUMN', parameters('azureSearchOffsetColumn'), 'AZURE_SEARCH_TOP_K', parameters('azureSearchTopK')), if(equals(parameters('databaseType'), 'PostgreSQL'), createObject('AZURE_POSTGRESQL_HOST_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLServerName, 'AZURE_POSTGRESQL_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLDatabaseName, 'AZURE_POSTGRESQL_USER', parameters('functionName')), createObject())))]"
           }
         },
         "template": {
@@ -7803,8 +7810,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "8495509026134584506"
+              "version": "0.36.177.2456",
+              "templateHash": "7804437003913110787"
             }
           },
           "parameters": {
@@ -7937,8 +7944,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "14064779471734903875"
+                      "version": "0.36.177.2456",
+                      "templateHash": "17828501769274035790"
                     },
                     "description": "Creates an Azure Function in an existing Azure App Service plan."
                   },
@@ -8145,8 +8152,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.36.1.42791",
-                              "templateHash": "17297314312801200043"
+                              "version": "0.36.177.2456",
+                              "templateHash": "211085466725967833"
                             },
                             "description": "Creates an Azure App Service in an existing Azure App Service plan."
                           },
@@ -8372,8 +8379,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.36.1.42791",
-                                      "templateHash": "8872422051335608470"
+                                      "version": "0.36.177.2456",
+                                      "templateHash": "2114937881746412139"
                                     },
                                     "description": "Updates app settings for an Azure App Service."
                                   },
@@ -8449,8 +8456,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.36.1.42791",
-                              "templateHash": "1525080529756490231"
+                              "version": "0.36.177.2456",
+                              "templateHash": "14223167216489085881"
                             },
                             "description": "Creates a role assignment for a service principal."
                           },
@@ -8539,8 +8546,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -8607,8 +8614,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -8675,8 +8682,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -8743,8 +8750,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -8811,8 +8818,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -8876,8 +8883,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "13097350302282890335"
+                      "version": "0.36.177.2456",
+                      "templateHash": "15649900872986233495"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -8993,7 +9000,7 @@
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'keyvault'), '2022-09-01').outputs.name.value]"
           },
           "appSettings": {
-            "value": "[union(createObject('AZURE_BLOB_ACCOUNT_NAME', parameters('storageAccountName'), 'AZURE_BLOB_CONTAINER_NAME', variables('blobContainerName'), 'AZURE_FORM_RECOGNIZER_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('formRecognizerName')), '2022-09-01').outputs.endpoint.value, 'AZURE_COMPUTER_VISION_ENDPOINT', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.endpoint.value, ''), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_API_VERSION', parameters('computerVisionVectorizeImageApiVersion'), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_MODEL_VERSION', parameters('computerVisionVectorizeImageModelVersion'), 'AZURE_CONTENT_SAFETY_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('contentSafetyName')), '2022-09-01').outputs.endpoint.value, 'AZURE_OPENAI_MODEL', parameters('azureOpenAIModel'), 'AZURE_OPENAI_MODEL_NAME', parameters('azureOpenAIModelName'), 'AZURE_OPENAI_MODEL_VERSION', parameters('azureOpenAIModelVersion'), 'AZURE_OPENAI_EMBEDDING_MODEL', parameters('azureOpenAIEmbeddingModel'), 'AZURE_OPENAI_EMBEDDING_MODEL_NAME', parameters('azureOpenAIEmbeddingModelName'), 'AZURE_OPENAI_EMBEDDING_MODEL_VERSION', parameters('azureOpenAIEmbeddingModelVersion'), 'AZURE_OPENAI_RESOURCE', parameters('azureOpenAIResourceName'), 'AZURE_OPENAI_API_VERSION', parameters('azureOpenAIApiVersion'), 'USE_ADVANCED_IMAGE_PROCESSING', parameters('useAdvancedImageProcessing'), 'DOCUMENT_PROCESSING_QUEUE_NAME', variables('queueName'), 'ORCHESTRATION_STRATEGY', parameters('orchestrationStrategy'), 'LOGLEVEL', parameters('logLevel'), 'AZURE_OPENAI_SYSTEM_MESSAGE', parameters('azureOpenAISystemMessage'), 'DATABASE_TYPE', parameters('databaseType')), if(equals(parameters('databaseType'), 'CosmosDB'), createObject('AZURE_SEARCH_INDEX', parameters('azureSearchIndex'), 'AZURE_SEARCH_SERVICE', format('https://{0}.search.windows.net', parameters('azureAISearchName')), 'AZURE_SEARCH_DATASOURCE_NAME', parameters('azureSearchDatasource'), 'AZURE_SEARCH_INDEXER_NAME', parameters('azureSearchIndexer'), 'AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION', parameters('azureSearchUseIntegratedVectorization'), 'AZURE_SEARCH_FIELDS_ID', parameters('azureSearchFieldId'), 'AZURE_SEARCH_CONTENT_COLUMN', parameters('azureSearchContentColumn'), 'AZURE_SEARCH_CONTENT_VECTOR_COLUMN', parameters('azureSearchVectorColumn'), 'AZURE_SEARCH_TITLE_COLUMN', parameters('azureSearchTitleColumn'), 'AZURE_SEARCH_FIELDS_METADATA', parameters('azureSearchFieldsMetadata'), 'AZURE_SEARCH_SOURCE_COLUMN', parameters('azureSearchSourceColumn'), 'AZURE_SEARCH_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchTextColumn'), ''), 'AZURE_SEARCH_LAYOUT_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchLayoutTextColumn'), ''), 'AZURE_SEARCH_CHUNK_COLUMN', parameters('azureSearchChunkColumn'), 'AZURE_SEARCH_OFFSET_COLUMN', parameters('azureSearchOffsetColumn'), 'AZURE_SEARCH_TOP_K', parameters('azureSearchTopK')), if(equals(parameters('databaseType'), 'PostgreSQL'), createObject('AZURE_POSTGRESQL_HOST_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLServerName, 'AZURE_POSTGRESQL_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLDatabaseName, 'AZURE_POSTGRESQL_USER', format('{0}-docker', parameters('functionName'))), createObject())))]"
+            "value": "[union(createObject('AZURE_BLOB_ACCOUNT_NAME', parameters('storageAccountName'), 'AZURE_BLOB_CONTAINER_NAME', variables('blobContainerName'), 'AZURE_FORM_RECOGNIZER_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('formRecognizerName')), '2022-09-01').outputs.endpoint.value, 'AZURE_COMPUTER_VISION_ENDPOINT', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.endpoint.value, ''), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_API_VERSION', parameters('computerVisionVectorizeImageApiVersion'), 'AZURE_COMPUTER_VISION_VECTORIZE_IMAGE_MODEL_VERSION', parameters('computerVisionVectorizeImageModelVersion'), 'AZURE_CONTENT_SAFETY_ENDPOINT', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', parameters('contentSafetyName')), '2022-09-01').outputs.endpoint.value, 'AZURE_OPENAI_MODEL', parameters('azureOpenAIModel'), 'AZURE_OPENAI_MODEL_NAME', parameters('azureOpenAIModelName'), 'AZURE_OPENAI_MODEL_VERSION', parameters('azureOpenAIModelVersion'), 'AZURE_OPENAI_EMBEDDING_MODEL', parameters('azureOpenAIEmbeddingModel'), 'AZURE_OPENAI_EMBEDDING_MODEL_NAME', parameters('azureOpenAIEmbeddingModelName'), 'AZURE_OPENAI_EMBEDDING_MODEL_VERSION', parameters('azureOpenAIEmbeddingModelVersion'), 'AZURE_OPENAI_RESOURCE', parameters('azureOpenAIResourceName'), 'AZURE_OPENAI_API_VERSION', parameters('azureOpenAIApiVersion'), 'USE_ADVANCED_IMAGE_PROCESSING', parameters('useAdvancedImageProcessing'), 'DOCUMENT_PROCESSING_QUEUE_NAME', variables('queueName'), 'ORCHESTRATION_STRATEGY', parameters('orchestrationStrategy'), 'LOGLEVEL', parameters('logLevel'), 'AZURE_OPENAI_SYSTEM_MESSAGE', parameters('azureOpenAISystemMessage'), 'DATABASE_TYPE', parameters('databaseType'), 'APP_ENV', parameters('appEnvironment')), if(equals(parameters('databaseType'), 'CosmosDB'), createObject('AZURE_SEARCH_INDEX', parameters('azureSearchIndex'), 'AZURE_SEARCH_SERVICE', format('https://{0}.search.windows.net', parameters('azureAISearchName')), 'AZURE_SEARCH_DATASOURCE_NAME', parameters('azureSearchDatasource'), 'AZURE_SEARCH_INDEXER_NAME', parameters('azureSearchIndexer'), 'AZURE_SEARCH_USE_INTEGRATED_VECTORIZATION', parameters('azureSearchUseIntegratedVectorization'), 'AZURE_SEARCH_FIELDS_ID', parameters('azureSearchFieldId'), 'AZURE_SEARCH_CONTENT_COLUMN', parameters('azureSearchContentColumn'), 'AZURE_SEARCH_CONTENT_VECTOR_COLUMN', parameters('azureSearchVectorColumn'), 'AZURE_SEARCH_TITLE_COLUMN', parameters('azureSearchTitleColumn'), 'AZURE_SEARCH_FIELDS_METADATA', parameters('azureSearchFieldsMetadata'), 'AZURE_SEARCH_SOURCE_COLUMN', parameters('azureSearchSourceColumn'), 'AZURE_SEARCH_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchTextColumn'), ''), 'AZURE_SEARCH_LAYOUT_TEXT_COLUMN', if(parameters('azureSearchUseIntegratedVectorization'), parameters('azureSearchLayoutTextColumn'), ''), 'AZURE_SEARCH_CHUNK_COLUMN', parameters('azureSearchChunkColumn'), 'AZURE_SEARCH_OFFSET_COLUMN', parameters('azureSearchOffsetColumn'), 'AZURE_SEARCH_TOP_K', parameters('azureSearchTopK')), if(equals(parameters('databaseType'), 'PostgreSQL'), createObject('AZURE_POSTGRESQL_HOST_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLServerName, 'AZURE_POSTGRESQL_DATABASE_NAME', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_postgres_sql'), '2022-09-01').outputs.postgresDbOutput.value.postgreSQLDatabaseName, 'AZURE_POSTGRESQL_USER', format('{0}-docker', parameters('functionName'))), createObject())))]"
           }
         },
         "template": {
@@ -9002,8 +9009,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "8495509026134584506"
+              "version": "0.36.177.2456",
+              "templateHash": "7804437003913110787"
             }
           },
           "parameters": {
@@ -9136,8 +9143,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "14064779471734903875"
+                      "version": "0.36.177.2456",
+                      "templateHash": "17828501769274035790"
                     },
                     "description": "Creates an Azure Function in an existing Azure App Service plan."
                   },
@@ -9344,8 +9351,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.36.1.42791",
-                              "templateHash": "17297314312801200043"
+                              "version": "0.36.177.2456",
+                              "templateHash": "211085466725967833"
                             },
                             "description": "Creates an Azure App Service in an existing Azure App Service plan."
                           },
@@ -9571,8 +9578,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.36.1.42791",
-                                      "templateHash": "8872422051335608470"
+                                      "version": "0.36.177.2456",
+                                      "templateHash": "2114937881746412139"
                                     },
                                     "description": "Updates app settings for an Azure App Service."
                                   },
@@ -9648,8 +9655,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.36.1.42791",
-                              "templateHash": "1525080529756490231"
+                              "version": "0.36.177.2456",
+                              "templateHash": "14223167216489085881"
                             },
                             "description": "Creates a role assignment for a service principal."
                           },
@@ -9738,8 +9745,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -9806,8 +9813,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -9874,8 +9881,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -9942,8 +9949,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -10010,8 +10017,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "1525080529756490231"
+                      "version": "0.36.177.2456",
+                      "templateHash": "14223167216489085881"
                     },
                     "description": "Creates a role assignment for a service principal."
                   },
@@ -10075,8 +10082,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "13097350302282890335"
+                      "version": "0.36.177.2456",
+                      "templateHash": "15649900872986233495"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -10182,8 +10189,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "5396502874055092713"
+              "version": "0.36.177.2456",
+              "templateHash": "10797488511727118382"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -10337,8 +10344,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "5396502874055092713"
+              "version": "0.36.177.2456",
+              "templateHash": "10797488511727118382"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -10495,8 +10502,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "8223498772551098397"
+              "version": "0.36.177.2456",
+              "templateHash": "6867239882926035710"
             }
           },
           "parameters": {
@@ -10625,8 +10632,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "14433511087095141274"
+              "version": "0.36.177.2456",
+              "templateHash": "751274412433583119"
             },
             "description": "Creates an Azure storage account."
           },
@@ -10846,8 +10853,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "1525080529756490231"
+              "version": "0.36.177.2456",
+              "templateHash": "14223167216489085881"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -10916,8 +10923,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "1525080529756490231"
+              "version": "0.36.177.2456",
+              "templateHash": "14223167216489085881"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -10986,8 +10993,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "1525080529756490231"
+              "version": "0.36.177.2456",
+              "templateHash": "14223167216489085881"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -11056,8 +11063,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "1525080529756490231"
+              "version": "0.36.177.2456",
+              "templateHash": "14223167216489085881"
             },
             "description": "Creates a role assignment for a service principal."
           },
@@ -11137,8 +11144,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "7527931742843464990"
+              "version": "0.36.177.2456",
+              "templateHash": "2489728688695786416"
             }
           },
           "parameters": {
@@ -11275,8 +11282,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "7556565821952147924"
+              "version": "0.36.177.2456",
+              "templateHash": "10392671673595303284"
             }
           },
           "parameters": {
@@ -11355,13 +11362,17 @@
       "type": "string",
       "value": "[parameters('hostingModel')]"
     },
+    "APP_ENV": {
+      "type": "string",
+      "value": "[parameters('appEnvironment')]"
+    },
     "AZURE_BLOB_STORAGE_INFO": {
       "type": "string",
       "value": "[variables('azureBlobStorageInfo')]"
     },
     "AZURE_COMPUTER_VISION_INFO": {
       "type": "string",
-      "value": "[string(createObject('service_name', parameters('speechServiceName'), 'endpoint', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.endpoint.value, ''), 'location', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.location.value, ''), 'vectorize_image_api_version', parameters('computerVisionVectorizeImageApiVersion'), 'vectorize_image_model_version', parameters('computerVisionVectorizeImageModelVersion')))]"
+      "value": "[string(createObject('service_name', parameters('computerVisionName'), 'endpoint', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.endpoint.value, ''), 'location', if(parameters('useAdvancedImageProcessing'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'computerVision'), '2022-09-01').outputs.location.value, ''), 'vectorize_image_api_version', parameters('computerVisionVectorizeImageApiVersion'), 'vectorize_image_model_version', parameters('computerVisionVectorizeImageModelVersion')))]"
     },
     "AZURE_CONTENT_SAFETY_INFO": {
       "type": "string",
@@ -11471,7 +11482,7 @@
       "type": "string",
       "value": "[variables('openAIFunctionsSystemPrompt')]"
     },
-    "SEMENTIC_KERNEL_SYSTEM_PROMPT": {
+    "SEMANTIC_KERNEL_SYSTEM_PROMPT": {
       "type": "string",
       "value": "[variables('semanticKernelSystemPrompt')]"
     }

--- a/scripts/data_scripts/create_postgres_tables.py
+++ b/scripts/data_scripts/create_postgres_tables.py
@@ -1,4 +1,6 @@
-from azure.identity import DefaultAzureCredential
+from ..code.backend.batch.utilities.helpers.azure_credential_utils import (
+    get_azure_credential,
+)
 import psycopg2
 from psycopg2 import sql
 
@@ -61,7 +63,7 @@ def grant_permissions(cursor, dbname, schema_name, principal_name):
 
 
 # Acquire the access token
-cred = DefaultAzureCredential()
+cred = get_azure_credential()
 access_token = cred.get_token("https://ossrdbms-aad.database.windows.net/.default")
 
 # Combine the token with the connection string to establish the connection.

--- a/scripts/data_scripts/requirements.txt
+++ b/scripts/data_scripts/requirements.txt
@@ -1,3 +1,3 @@
 psycopg2-binary==2.9.10
-azure-identity==1.19.0
-azure-keyvault-secrets==4.9.0
+azure-identity==1.23.1
+azure-keyvault-secrets==4.7.0


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request introduces a refactor to replace the usage of `DefaultAzureCredential` with a new helper function `get_azure_credential`, which dynamically selects the appropriate credential type based on the application environment (`APP_ENV`). Additionally, it includes minor fixes and adjustments to environment variable names. Below are the most important changes grouped by theme:

### Credential Refactor:
* [`code/backend/batch/utilities/helpers/azure_credential_utils.py`](diffhunk://#diff-7da5073cced326c7dced13c0768484d67ae146b74dd907b44ebc20eb78bb9a7bR1-R48): Added the `get_azure_credential` and `get_azure_credential_async` functions to dynamically select between `DefaultAzureCredential` and `ManagedIdentityCredential` based on the environment (`APP_ENV`).
* Updated multiple files across the codebase to replace `DefaultAzureCredential` with `get_azure_credential` for consistent credential handling:
  - `database_factory.py` [[1]](diffhunk://#diff-a92ad8584f19aec266f80fe1d5decb9f8603008378f3c9c9cca31dc1401b3e29L5-R5) [[2]](diffhunk://#diff-a92ad8584f19aec266f80fe1d5decb9f8603008378f3c9c9cca31dc1401b3e29L28-R28)
  - `postgresdbservice.py` [[1]](diffhunk://#diff-e7dfe35613384cb3374f9b90a8ec2f7effb9e3f09f6c693636cce07fa4904987L4-R4) [[2]](diffhunk://#diff-e7dfe35613384cb3374f9b90a8ec2f7effb9e3f09f6c693636cce07fa4904987L24-R24)
  - `azure_blob_storage_client.py` [[1]](diffhunk://#diff-0501618008f86eacf193f09a72a1f5ec7bf348b4b19e5c937657d62e039a75f3L15-R15) [[2]](diffhunk://#diff-0501618008f86eacf193f09a72a1f5ec7bf348b4b19e5c937657d62e039a75f3L28-R28) [[3]](diffhunk://#diff-0501618008f86eacf193f09a72a1f5ec7bf348b4b19e5c937657d62e039a75f3L59-R59)
  - `azure_computer_vision_client.py` [[1]](diffhunk://#diff-b228a7a21f60cbc2f450086e1f8b430ab70df4579c1dae4c91dcc9d60477804fL3-R4) [[2]](diffhunk://#diff-b228a7a21f60cbc2f450086e1f8b430ab70df4579c1dae4c91dcc9d60477804fL59-R60)
  - `azure_form_recognizer_helper.py` [[1]](diffhunk://#diff-c2f405722abb3fba86580c300caa1b9e14ea410594b11765a470cdbb703f5011L4-R4) [[2]](diffhunk://#diff-c2f405722abb3fba86580c300caa1b9e14ea410594b11765a470cdbb703f5011L22-R22)
  - `azure_postgres_helper.py` [[1]](diffhunk://#diff-50e3408b3f05e1cdccee7e3d8138209baebda958477121fe6a7e7c8289b89060L4-R4) [[2]](diffhunk://#diff-50e3408b3f05e1cdccee7e3d8138209baebda958477121fe6a7e7c8289b89060L27-R27)
  - `azure_search_helper.py` [[1]](diffhunk://#diff-8acbb6b44f9a1c4104fd339b585d57d8d628f8ceace3ccc6db9266b23c3106a7L5-R5) [[2]](diffhunk://#diff-8acbb6b44f9a1c4104fd339b585d57d8d628f8ceace3ccc6db9266b23c3106a7L52-R55) [[3]](diffhunk://#diff-8acbb6b44f9a1c4104fd339b585d57d8d628f8ceace3ccc6db9266b23c3106a7L64-R64) [[4]](diffhunk://#diff-8acbb6b44f9a1c4104fd339b585d57d8d628f8ceace3ccc6db9266b23c3106a7L288-R288)
  - `env_helper.py` [[1]](diffhunk://#diff-7503275e90a545dba3519622ff9d0866a73e814ddbfbb61156137721bf2a6552L6-L8) [[2]](diffhunk://#diff-7503275e90a545dba3519622ff9d0866a73e814ddbfbb61156137721bf2a6552L219-R219) [[3]](diffhunk://#diff-7503275e90a545dba3519622ff9d0866a73e814ddbfbb61156137721bf2a6552L432-R432)
  - `llm_helper.py` [[1]](diffhunk://#diff-43896759bad4bc2119807845cbb205a535d9caec19b671e07dcb6cfe73ec421aL11-R11) [[2]](diffhunk://#diff-43896759bad4bc2119807845cbb205a535d9caec19b671e07dcb6cfe73ec421aL169-R169)
  - `azure_search_datasource.py` [[1]](diffhunk://#diff-191306cd0087ff3adec6be22022a25f09ad71cd8596aebb0050de612ec0b091eL10-R10) [[2]](diffhunk://#diff-191306cd0087ff3adec6be22022a25f09ad71cd8596aebb0050de612ec0b091eL22-R22)
  - `azure_search_index.py` [[1]](diffhunk://#diff-9110c8709dac7271099ab02556bef8c9a110c6413badfff59eb0119c570d91a7L24-R24) [[2]](diffhunk://#diff-9110c8709dac7271099ab02556bef8c9a110c6413badfff59eb0119c570d91a7L42-R42)
  - `azure_search_indexer.py` [[1]](diffhunk://#diff-5a2966c08715e2d467100ebf3b4a58b5fc3a34159aee19f22c0341d50a929dfcL5-R5) [[2]](diffhunk://#diff-5a2966c08715e2d467100ebf3b4a58b5fc3a34159aee19f22c0341d50a929dfcL19-R19)

### Environment Variable Updates:
* [`.env.sample`](diffhunk://#diff-088d9f35d23a4347d221d71dd49b02b95001dff4abe637a40fe0bc04d502049cR63-R64): Added `APP_ENV` to specify the application environment (e.g., `dev`, `prod`) for dynamic credential selection.
* [`env_helper.py`](diffhunk://#diff-7503275e90a545dba3519622ff9d0866a73e814ddbfbb61156137721bf2a6552L365-R366): Corrected a typo in the environment variable name from `SEMENTIC_KERNEL_SYSTEM_PROMPT` to `SEMANTIC_KERNEL_SYSTEM_PROMPT`.

These changes improve the flexibility and maintainability of credential management across the codebase while ensuring consistency in environment variable usage.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```


## What to Check
Verify that the following are valid:

- All usages of DefaultAzureCredential replaced
- Authentication logic tested locally or in a dev environment
- Regression tested (i.e., existing functionality relying on authentication continues to work)
- Confirmed no hardcoded secrets or fallback dev credentials remain