### PR TITLE
feat: On click of button teatarea should be clear

### DIFF
--- a/code/backend/pages/01_Ingest_Data.py
+++ b/code/backend/pages/01_Ingest_Data.py
@@ -55,7 +55,10 @@ def reprocess_all():
 
 def add_urls():
     urls = st.session_state["urls"].split("\n")
-    add_url_embeddings(urls)
+    result = add_url_embeddings(urls)
+    # If URLs are valid and processed, clear the textarea
+    if result:
+        st.session_state["urls"] = ""
 
 
 def sanitize_metadata_value(value):
@@ -67,7 +70,7 @@ def add_url_embeddings(urls: list[str]):
     has_valid_url = bool(list(filter(str.strip, urls)))
     if not has_valid_url:
         st.error("Please enter at least one valid URL.")
-        return
+        return False
 
     params = {}
     if env_helper.FUNCTION_KEY is not None:
@@ -80,9 +83,11 @@ def add_url_embeddings(urls: list[str]):
         )
         r = requests.post(url=backend_url, params=params, json=body)
         if not r.ok:
-            raise ValueError(f"Error {r.status_code}: {r.text}")
+            st.error(f"Error {r.status_code}: {r.text}")
+            return False
         else:
             st.success(f"Embeddings added successfully for {url}")
+    return True
 
 
 try:


### PR DESCRIPTION
## Purpose
On clicking the 'Process and Ingest Web Pages' button, if the URL is valid, then clear the text area.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->


<img width="1907" height="969" alt="image" src="https://github.com/user-attachments/assets/5767de49-31b5-4710-9094-c5f62706af1e" />
