### PR TITLE
fix: fix byod flow and update integrated vectorization to work with byod flow

### DIFF
--- a/code/backend/batch/combine_pages_chunknos.py
+++ b/code/backend/batch/combine_pages_chunknos.py
@@ -1,0 +1,59 @@
+import logging
+import azure.functions as func
+import json
+
+bp_combine_pages_and_chunknos = func.Blueprint()
+
+@bp_combine_pages_and_chunknos.route(route="combine_pages_and_chunknos", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
+def combine_pages_and_chunknos(req: func.HttpRequest) -> func.HttpResponse:
+    """
+    This function is designed to be called by an Azure Cognitive Search WebApiSkill.
+    It expects a JSON payload with two arrays ("pages" and "chunk_nos") and
+    combines them into a single array of objects.
+    """
+    logging.info("Combine pages and chunk numbers function processed a request.")
+
+    try:
+        req_body = req.get_json()
+        logging.info(f"Request body: {req_body}")
+        values = req_body.get("values", [])
+
+        response_values = []
+
+        for value in values:
+            record_id = value.get("recordId")
+            data = value.get("data", {})
+
+            pages = data.get("pages", [])
+            chunk_nos = data.get("chunk_nos", [])
+
+            # Zip the two arrays together
+            zipped_data = [
+                {"page_text": page, "chunk_no": chunk}
+                for page, chunk in zip(pages, chunk_nos)
+            ]
+
+            response_values.append(
+                {
+                    "recordId": record_id,
+                    "data": {"pages_with_chunks": zipped_data},
+                    "errors": None,
+                    "warnings": None,
+                }
+            )
+
+        # Return the response in the format expected by the WebApiSkill
+        logging.info(f"Response values: {response_values}")
+        return func.HttpResponse(
+            body=json.dumps({"values": response_values}),
+            mimetype="application/json",
+            status_code=200,
+        )
+
+    except Exception as e:
+        logging.error(f"Error in combine_pages_and_chunknos function: {e}")
+        return func.HttpResponse(
+            body=json.dumps({"values": [{"recordId": "error", "data": {}, "errors": [{"message": str(e)}], "warnings": []}]}),
+            mimetype="application/json",
+            status_code=500,
+        )

--- a/code/backend/batch/function_app.py
+++ b/code/backend/batch/function_app.py
@@ -5,6 +5,7 @@ from add_url_embeddings import bp_add_url_embeddings
 from batch_push_results import bp_batch_push_results
 from batch_start_processing import bp_batch_start_processing
 from get_conversation_response import bp_get_conversation_response
+from combine_pages_chunknos import bp_combine_pages_and_chunknos
 from azure.monitor.opentelemetry import configure_azure_monitor
 
 logging.captureWarnings(True)
@@ -20,3 +21,4 @@ app.register_functions(bp_add_url_embeddings)
 app.register_functions(bp_batch_push_results)
 app.register_functions(bp_batch_start_processing)
 app.register_functions(bp_get_conversation_response)
+app.register_functions(bp_combine_pages_and_chunknos)

--- a/code/backend/batch/utilities/integrated_vectorization/azure_search_indexer.py
+++ b/code/backend/batch/utilities/integrated_vectorization/azure_search_indexer.py
@@ -1,5 +1,5 @@
 import logging
-from azure.search.documents.indexes.models import SearchIndexer, FieldMapping
+from azure.search.documents.indexes.models import SearchIndexer, FieldMapping, FieldMappingFunction
 from azure.search.documents.indexes import SearchIndexerClient
 from ..helpers.env_helper import EnvHelper
 from ..helpers.azure_credential_utils import get_azure_credential
@@ -35,6 +35,13 @@ class AzureSearchIndexer:
                 }
             },
             field_mappings=[
+                FieldMapping(
+                    source_field_name="metadata_storage_path",
+                    target_field_name="id",
+                    mapping_function=FieldMappingFunction(
+                        name="base64Encode", parameters={"useHttpServerUtilityUrlTokenEncode": False}
+                    )
+                ),
                 FieldMapping(
                     source_field_name="metadata_storage_path",
                     target_field_name="source",

--- a/code/backend/batch/utilities/integrated_vectorization/azure_search_skillset.py
+++ b/code/backend/batch/utilities/integrated_vectorization/azure_search_skillset.py
@@ -6,6 +6,8 @@ from azure.search.documents.indexes.models import (
     AzureOpenAIEmbeddingSkill,
     OcrSkill,
     MergeSkill,
+    ShaperSkill,
+    WebApiSkill,
     SearchIndexerIndexProjections,
     SearchIndexerIndexProjectionSelector,
     SearchIndexerIndexProjectionsParameters,
@@ -82,12 +84,30 @@ class AzureSearchSkillset:
             inputs=[
                 InputFieldMappingEntry(name="text", source="/document/merged_content"),
             ],
-            outputs=[OutputFieldMappingEntry(name="textItems", target_name="pages")],
+            outputs=[
+                OutputFieldMappingEntry(name="textItems", target_name="pages"),
+                OutputFieldMappingEntry(name="ordinalPositions", target_name="chunk_nos"),
+                ],
+        )
+
+        # Custom WebApi skill to combine pages and chunk numbers into a single structure
+        combine_pages_and_chunk_nos_skill = WebApiSkill(
+            description="Combine pages and chunk numbers together",
+            context="/document",
+            uri=f"{self.env_helper.BACKEND_URL}/api/combine_pages_and_chunknos",
+            http_method="POST",
+            inputs=[
+                InputFieldMappingEntry(name="pages", source="/document/pages"),
+                InputFieldMappingEntry(name="chunk_nos", source="/document/chunk_nos"),
+            ],
+            outputs=[
+                OutputFieldMappingEntry(name="pages_with_chunks", target_name="pages_with_chunks")
+            ]
         )
 
         embedding_skill = AzureOpenAIEmbeddingSkill(
             description="Skill to generate embeddings via Azure OpenAI",
-            context="/document/pages/*",
+            context="/document/pages_with_chunks/*",
             resource_uri=self.env_helper.AZURE_OPENAI_ENDPOINT,
             deployment_id=self.env_helper.AZURE_OPENAI_EMBEDDING_MODEL,
             api_key=(
@@ -96,11 +116,25 @@ class AzureSearchSkillset:
                 else None
             ),
             inputs=[
-                InputFieldMappingEntry(name="text", source="/document/pages/*"),
+                InputFieldMappingEntry(name="text", source="/document/pages_with_chunks/*/page_text"),
             ],
             outputs=[
                 OutputFieldMappingEntry(name="embedding", target_name="content_vector")
             ],
+        )
+
+        metadata_shaper = ShaperSkill(
+            description="Structure metadata fields into a complex object",
+            context="/document/pages_with_chunks/*",
+            inputs=[
+                InputFieldMappingEntry(name="id", source="/document/id"),
+                InputFieldMappingEntry(name="source", source="/document/metadata_storage_path"),
+                InputFieldMappingEntry(name="title", source="/document/title"),
+                InputFieldMappingEntry(name="chunk", source="/document/pages_with_chunks/*/chunk_no"),
+            ],
+            outputs=[
+                OutputFieldMappingEntry(name="output", target_name="metadata_object")
+            ]
         )
 
         index_projections = SearchIndexerIndexProjections(
@@ -108,19 +142,23 @@ class AzureSearchSkillset:
                 SearchIndexerIndexProjectionSelector(
                     target_index_name=self.env_helper.AZURE_SEARCH_INDEX,
                     parent_key_field_name="id",
-                    source_context="/document/pages/*",
+                    source_context="/document/pages_with_chunks/*",
                     mappings=[
                         InputFieldMappingEntry(
-                            name="content", source="/document/pages/*"
+                            name="content", source="/document/pages_with_chunks/*/page_text"
                         ),
                         InputFieldMappingEntry(
                             name="content_vector",
-                            source="/document/pages/*/content_vector",
+                            source="/document/pages_with_chunks/*/content_vector",
                         ),
                         InputFieldMappingEntry(name="title", source="/document/title"),
                         InputFieldMappingEntry(
                             name="source", source="/document/metadata_storage_path"
                         ),
+                        InputFieldMappingEntry(
+                            name="metadata",
+                            source="/document/pages_with_chunks/*/metadata_object",
+                        )
                     ],
                 ),
             ],
@@ -132,7 +170,7 @@ class AzureSearchSkillset:
         skillset = SearchIndexerSkillset(
             name=skillset_name,
             description="Skillset to chunk documents and generating embeddings",
-            skills=[ocr_skill, merge_skill, split_skill, embedding_skill],
+            skills=[ocr_skill, merge_skill, split_skill, combine_pages_and_chunk_nos_skill, embedding_skill, metadata_shaper],
             index_projections=index_projections,
         )
 

--- a/code/create_app.py
+++ b/code/create_app.py
@@ -54,14 +54,17 @@ def get_citations(citation_list):
             else citation["url"]
         )
         title = citation["title"]
-        url = get_markdown_url(metadata["source"], title, container_sas)
+        source = metadata["source"]
+        if "_SAS_TOKEN_PLACEHOLDER_" not in source:
+            source += "_SAS_TOKEN_PLACEHOLDER_"
+        url = get_markdown_url(source, title, container_sas)
         citations_dict["citations"].append(
             {
                 "content": url + "\n\n\n" + citation["content"],
                 "id": metadata["id"],
                 "chunk_id": (
                     re.findall(r"\d+", metadata["chunk_id"])[-1]
-                    if metadata["chunk_id"] is not None
+                    if metadata.get("chunk_id") is not None
                     else metadata["chunk"]
                 ),
                 "title": title,
@@ -209,11 +212,6 @@ def conversation_with_data(conversation: Request, env_helper: EnvHelper):
                                 env_helper.AZURE_SEARCH_CONTENT_VECTOR_COLUMN
                             ],
                             "title_field": env_helper.AZURE_SEARCH_TITLE_COLUMN or None,
-                            "source_field": env_helper.AZURE_SEARCH_SOURCE_COLUMN
-                            or None,
-                            "text_field": env_helper.AZURE_SEARCH_TEXT_COLUMN or None,
-                            "layoutText_field": env_helper.AZURE_SEARCH_LAYOUT_TEXT_COLUMN
-                            or None,
                             "url_field": env_helper.AZURE_SEARCH_FIELDS_METADATA
                             or None,
                             "filepath_field": (

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1016,6 +1016,7 @@ module function './app/function.bicep' = if (hostingModel == 'code') {
         AZURE_OPENAI_SYSTEM_MESSAGE: azureOpenAISystemMessage
         DATABASE_TYPE: databaseType
         APP_ENV: appEnvironment
+        BACKEND_URL: backendUrl
       },
       // Conditionally add database-specific settings
       databaseType == 'CosmosDB'
@@ -1086,6 +1087,7 @@ module function_docker './app/function.bicep' = if (hostingModel == 'container')
         AZURE_OPENAI_SYSTEM_MESSAGE: azureOpenAISystemMessage
         DATABASE_TYPE: databaseType
         APP_ENV: appEnvironment
+        BACKEND_URL: backendUrl
       },
       // Conditionally add database-specific settings
       databaseType == 'CosmosDB'
@@ -1363,7 +1365,7 @@ var azureContentSafetyInfo = string({
   endpoint: contentsafety.outputs.endpoint
 })
 
-var backendUrl = 'https://${functionName}.azurewebsites.net'
+var backendUrl = hostingModel == 'container' ? 'https://${functionName}-docker.azurewebsites.net' : 'https://${functionName}.azurewebsites.net'
 
 output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.applicationInsightsConnectionString
 output AZURE_APP_SERVICE_HOSTING_MODEL string = hostingModel


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request introduces a new custom Azure Function and integrates it into the Azure Cognitive Search indexing pipeline to improve how document pages and chunk numbers are handled. It also updates the infrastructure to support these changes and fixes a minor bug in citation URL handling.

**Key changes include:**

### Azure Search Skillset and Indexer Enhancements

* Added a new custom Azure Function (`combine_pages_and_chunknos.py`) that combines arrays of page texts and chunk numbers into a structured array of objects, designed for use as a WebApiSkill in the Azure Search skillset.
* Integrated the new WebApiSkill into the search skillset, updating the pipeline to use the combined page/chunk structure for embedding and metadata shaping. This includes adding a `ShaperSkill` to structure metadata and modifying the skillset to use the new data flow. [[1]](diffhunk://#diff-8a457e956ca4a795232b2f94afeb5edda54514755b3d02384e0909658c609341L85-R110) [[2]](diffhunk://#diff-8a457e956ca4a795232b2f94afeb5edda54514755b3d02384e0909658c609341L99-R161) [[3]](diffhunk://#diff-8a457e956ca4a795232b2f94afeb5edda54514755b3d02384e0909658c609341L135-R173)
* Updated the indexer to use a `FieldMappingFunction` for base64 encoding the `id` field and to map new fields as required by the updated skillset. [[1]](diffhunk://#diff-5a2966c08715e2d467100ebf3b4a58b5fc3a34159aee19f22c0341d50a929dfcL2-R2) [[2]](diffhunk://#diff-5a2966c08715e2d467100ebf3b4a58b5fc3a34159aee19f22c0341d50a929dfcR38-R44)

### Application and Infrastructure Integration

* Registered the new function blueprint in `function_app.py` and ensured it is included in the application. [[1]](diffhunk://#diff-44d35a656fe640bc8eeecb042e3df17ab917a868c0af86c5e265456aa2ad9146R8) [[2]](diffhunk://#diff-44d35a656fe640bc8eeecb042e3df17ab917a868c0af86c5e265456aa2ad9146R24)
* Updated infrastructure (`main.bicep`) to provide the backend URL as an environment variable, with correct handling for both code and container hosting models. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R1019) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R1090) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1366-R1368)

### Bug Fix

* Fixed a bug in `create_app.py` where the citation source URL might be missing a placeholder, ensuring consistent URL formatting.

These changes collectively enable more robust and structured handling of document chunking and metadata in the Azure Search pipeline, and ensure the backend is properly configured for these new capabilities.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
