### PR TITLE
fix: Refactor OpenAI Networking for Integrated Vectorization Compatibility

### DIFF
--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "16084976593064189931"
+      "templateHash": "3641818015648077245"
     }
   },
   "parameters": {
@@ -699,6 +699,7 @@
       }
     ],
     "openAiDeployments": "[concat(variables('defaultOpenAiDeployments'), if(parameters('useAdvancedImageProcessing'), createArray(createObject('name', parameters('azureOpenAIVisionModel'), 'model', createObject('format', 'OpenAI', 'name', parameters('azureOpenAIVisionModelName'), 'version', parameters('azureOpenAIVisionModelVersion')), 'sku', createObject('name', 'GlobalStandard', 'capacity', parameters('azureOpenAIVisionModelCapacity')))), createArray()))]",
+    "enablePrivateNetworkingForOpenAI": "[and(parameters('enablePrivateNetworking'), equals(parameters('azureSearchUseIntegratedVectorization'), false()))]",
     "webServerFarmResourceName": "[variables('hostingPlanName')]",
     "azureOpenAIModelInfo": "[string(createObject('model', parameters('azureOpenAIModel'), 'model_name', parameters('azureOpenAIModelName'), 'model_version', parameters('azureOpenAIModelVersion')))]",
     "azureOpenAIEmbeddingModelInfo": "[string(createObject('model', parameters('azureOpenAIEmbeddingModel'), 'model_name', parameters('azureOpenAIEmbeddingModelName'), 'model_version', parameters('azureOpenAIEmbeddingModelVersion')))]",
@@ -14292,11 +14293,11 @@
             ]
           },
           "enablePrivateNetworking": {
-            "value": "[parameters('enablePrivateNetworking')]"
+            "value": "[variables('enablePrivateNetworkingForOpenAI')]"
           },
-          "subnetResourceId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('network').outputs.subnetPrivateEndpointsResourceId.value), createObject('value', null()))]",
+          "subnetResourceId": "[if(variables('enablePrivateNetworkingForOpenAI'), createObject('value', reference('network').outputs.subnetPrivateEndpointsResourceId.value), createObject('value', null()))]",
           "logAnalyticsWorkspaceId": "[if(parameters('enableMonitoring'), createObject('value', reference('monitoring').outputs.logAnalyticsWorkspaceId.value), createObject('value', null()))]",
-          "privateDnsZoneResourceId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference(format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)).outputs.resourceId.value), createObject('value', ''))]",
+          "privateDnsZoneResourceId": "[if(variables('enablePrivateNetworkingForOpenAI'), createObject('value', reference(format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)).outputs.resourceId.value), createObject('value', ''))]",
           "roleAssignments": {
             "value": "[concat(createArray(createObject('roleDefinitionIdOrName', 'a97b65f3-24c7-4388-baec-2e87135dc908', 'principalId', reference('managedIdentityModule').outputs.principalId.value, 'principalType', 'ServicePrincipal'), createObject('roleDefinitionIdOrName', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd', 'principalId', reference('managedIdentityModule').outputs.principalId.value, 'principalType', 'ServicePrincipal')), if(not(empty(parameters('principalId'))), createArray(createObject('roleDefinitionIdOrName', 'a97b65f3-24c7-4388-baec-2e87135dc908', 'principalId', parameters('principalId'), 'principalType', 'User'), createObject('roleDefinitionIdOrName', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd', 'principalId', parameters('principalId'), 'principalType', 'User')), createArray()))]"
           }
@@ -48286,9 +48287,9 @@
         }
       },
       "dependsOn": [
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageFile)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "managedIdentityModule",
         "network"
       ]


### PR DESCRIPTION
## Purpose
This pull request updates the infrastructure configuration to ensure that private networking for Azure OpenAI is disabled when using integrated vectorization with Azure Cognitive Search, as required by the indexer. The changes refactor how private networking is enabled for OpenAI resources, making this logic explicit and consistent across both Bicep and generated ARM templates.

**Networking configuration improvements:**

* Introduced a new variable `enablePrivateNetworkingForOpenAI` in `infra/main.bicep` to disable private networking for OpenAI when integrated vectorization is enabled in Azure Cognitive Search. This ensures compatibility with the indexer requirements.
* Updated the OpenAI module parameters in `infra/main.bicep` to use `enablePrivateNetworkingForOpenAI` for `enablePrivateNetworking`, `subnetResourceId`, and `privateDnsZoneResourceId`, ensuring that networking settings are correctly applied based on the new logic.
* Changed the OpenAI module `dependsOn` clause to use `enablePrivateNetworkingForOpenAI` instead of the previous variable, aligning resource dependencies with the new networking logic.

**ARM template consistency:**

* Reflected the new networking logic in the generated `infra/main.json` ARM template by introducing the `enablePrivateNetworkingForOpenAI` variable, and updating OpenAI resource parameters to use this variable for networking-related properties. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R702) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L14295-R14300)

**Other minor updates:**

* Adjusted the order of dependencies for storage queue DNS zones in `infra/main.json` to maintain consistency.
* Updated template hash values and workbook contents formatting in `infra/main.json` to reflect regeneration and minor formatting changes. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L9-R9) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L39171-R39172) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L39210-R39211)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the Integrated vectorization flow
