### PR TITLE
fix: Update solutionLocation parameter to use dynamic location value

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -382,7 +382,7 @@ module postgresDBModule './core/database/postgresdb.bicep' = if (databaseType ==
   name: 'deploy_postgres_sql'
   params: {
     solutionName: azurePostgresDBAccountName
-    solutionLocation: 'eastus2'
+    solutionLocation: location
     managedIdentityObjectId: managedIdentityModule.outputs.managedIdentityOutput.objectId
     managedIdentityObjectName: managedIdentityModule.outputs.managedIdentityOutput.name
     allowAzureIPsFirewall: true

--- a/infra/main.json
+++ b/infra/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.37.4.10188",
-      "templateHash": "4047273265154997995"
+      "version": "0.36.1.42791",
+      "templateHash": "1202307124278967054"
     }
   },
   "parameters": {
@@ -966,8 +966,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "1968061685319365829"
+              "version": "0.36.1.42791",
+              "templateHash": "13552365542706136811"
             }
           },
           "parameters": {
@@ -1058,8 +1058,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "9439710827049703630"
+              "version": "0.36.1.42791",
+              "templateHash": "16238674825125616801"
             }
           },
           "parameters": {
@@ -1212,7 +1212,7 @@
             "value": "[parameters('azurePostgresDBAccountName')]"
           },
           "solutionLocation": {
-            "value": "eastus2"
+            "value": "[parameters('location')]"
           },
           "managedIdentityObjectId": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('rgName')), 'Microsoft.Resources/deployments', 'deploy_managed_identity'), '2022-09-01').outputs.managedIdentityOutput.value.objectId]"
@@ -1230,8 +1230,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "415483108976286101"
+              "version": "0.36.1.42791",
+              "templateHash": "18258663885754684875"
             }
           },
           "parameters": {
@@ -1459,8 +1459,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "17153527614561574372"
+              "version": "0.36.1.42791",
+              "templateHash": "13654700215438528863"
             },
             "description": "Creates an Azure Key Vault."
           },
@@ -1561,8 +1561,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "10763707742517041475"
+              "version": "0.36.1.42791",
+              "templateHash": "5396502874055092713"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -1720,8 +1720,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "10763707742517041475"
+              "version": "0.36.1.42791",
+              "templateHash": "5396502874055092713"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -1872,8 +1872,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "7487840142945032587"
+              "version": "0.36.1.42791",
+              "templateHash": "4997140108958528754"
             },
             "description": "Creates a role assignment for a principal."
           },
@@ -1942,8 +1942,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "7487840142945032587"
+              "version": "0.36.1.42791",
+              "templateHash": "4997140108958528754"
             },
             "description": "Creates a role assignment for a principal."
           },
@@ -2013,8 +2013,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "7487840142945032587"
+              "version": "0.36.1.42791",
+              "templateHash": "4997140108958528754"
             },
             "description": "Creates a role assignment for a principal."
           },
@@ -2084,8 +2084,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "7487840142945032587"
+              "version": "0.36.1.42791",
+              "templateHash": "4997140108958528754"
             },
             "description": "Creates a role assignment for a principal."
           },
@@ -2159,8 +2159,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "10763707742517041475"
+              "version": "0.36.1.42791",
+              "templateHash": "5396502874055092713"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -2308,8 +2308,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "583973648717066932"
+              "version": "0.36.1.42791",
+              "templateHash": "15387352767143583863"
             }
           },
           "parameters": {
@@ -2386,8 +2386,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "1094478449749927695"
+              "version": "0.36.1.42791",
+              "templateHash": "7022850395133125583"
             },
             "description": "Creates an Azure AI Search instance."
           },
@@ -2555,8 +2555,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "16550655511404474484"
+              "version": "0.36.1.42791",
+              "templateHash": "8289034454652170240"
             },
             "description": "Creates an Azure App Service plan."
           },
@@ -2666,8 +2666,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "13346825141197852113"
+              "version": "0.36.1.42791",
+              "templateHash": "10467428237136730735"
             }
           },
           "parameters": {
@@ -2789,8 +2789,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "1852897590455041296"
+                      "version": "0.36.1.42791",
+                      "templateHash": "17297314312801200043"
                     },
                     "description": "Creates an Azure App Service in an existing Azure App Service plan."
                   },
@@ -3016,8 +3016,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "3192232430579364811"
+                              "version": "0.36.1.42791",
+                              "templateHash": "8872422051335608470"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -3093,8 +3093,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -3161,8 +3161,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -3229,8 +3229,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -3297,8 +3297,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -3362,8 +3362,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "2705323600886100029"
+                      "version": "0.36.1.42791",
+                      "templateHash": "13097350302282890335"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -3437,8 +3437,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "3534717300864928273"
+                      "version": "0.36.1.42791",
+                      "templateHash": "399023243105742355"
                     },
                     "description": "Creates a SQL role assignment under an Azure Cosmos DB account."
                   },
@@ -3550,8 +3550,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "13346825141197852113"
+              "version": "0.36.1.42791",
+              "templateHash": "10467428237136730735"
             }
           },
           "parameters": {
@@ -3673,8 +3673,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "1852897590455041296"
+                      "version": "0.36.1.42791",
+                      "templateHash": "17297314312801200043"
                     },
                     "description": "Creates an Azure App Service in an existing Azure App Service plan."
                   },
@@ -3900,8 +3900,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "3192232430579364811"
+                              "version": "0.36.1.42791",
+                              "templateHash": "8872422051335608470"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -3977,8 +3977,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -4045,8 +4045,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -4113,8 +4113,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -4181,8 +4181,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -4246,8 +4246,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "2705323600886100029"
+                      "version": "0.36.1.42791",
+                      "templateHash": "13097350302282890335"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -4321,8 +4321,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "3534717300864928273"
+                      "version": "0.36.1.42791",
+                      "templateHash": "399023243105742355"
                     },
                     "description": "Creates a SQL role assignment under an Azure Cosmos DB account."
                   },
@@ -4431,8 +4431,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "1962219056428670796"
+              "version": "0.36.1.42791",
+              "templateHash": "16494439279239342581"
             }
           },
           "parameters": {
@@ -4543,8 +4543,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "1852897590455041296"
+                      "version": "0.36.1.42791",
+                      "templateHash": "17297314312801200043"
                     },
                     "description": "Creates an Azure App Service in an existing Azure App Service plan."
                   },
@@ -4770,8 +4770,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "3192232430579364811"
+                              "version": "0.36.1.42791",
+                              "templateHash": "8872422051335608470"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -4847,8 +4847,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -4915,8 +4915,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -4983,8 +4983,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -5051,8 +5051,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -5116,8 +5116,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "2705323600886100029"
+                      "version": "0.36.1.42791",
+                      "templateHash": "13097350302282890335"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -5236,8 +5236,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "1962219056428670796"
+              "version": "0.36.1.42791",
+              "templateHash": "16494439279239342581"
             }
           },
           "parameters": {
@@ -5348,8 +5348,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "1852897590455041296"
+                      "version": "0.36.1.42791",
+                      "templateHash": "17297314312801200043"
                     },
                     "description": "Creates an Azure App Service in an existing Azure App Service plan."
                   },
@@ -5575,8 +5575,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "3192232430579364811"
+                              "version": "0.36.1.42791",
+                              "templateHash": "8872422051335608470"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -5652,8 +5652,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -5720,8 +5720,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -5788,8 +5788,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -5856,8 +5856,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -5921,8 +5921,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "2705323600886100029"
+                      "version": "0.36.1.42791",
+                      "templateHash": "13097350302282890335"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -6036,8 +6036,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "4153626622609270227"
+              "version": "0.36.1.42791",
+              "templateHash": "3170567318042083360"
             },
             "description": "Creates an Application Insights instance and a Log Analytics workspace."
           },
@@ -6095,8 +6095,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "14333383652080675454"
+                      "version": "0.36.1.42791",
+                      "templateHash": "18046713010447151328"
                     },
                     "description": "Creates a Log Analytics workspace."
                   },
@@ -6187,8 +6187,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "5691111495272459937"
+                      "version": "0.36.1.42791",
+                      "templateHash": "9396713012578391259"
                     },
                     "description": "Creates an Application Insights instance based on an existing Log Analytics workspace."
                   },
@@ -6252,8 +6252,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "12758358495379445390"
+                              "version": "0.36.1.42791",
+                              "templateHash": "4772814496944658769"
                             },
                             "description": "Creates a dashboard for an Application Insights instance."
                           },
@@ -7589,8 +7589,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "1100538149420181332"
+              "version": "0.36.1.42791",
+              "templateHash": "14423036048920164527"
             }
           },
           "parameters": {
@@ -7672,8 +7672,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7040393374365684354"
+                      "version": "0.36.1.42791",
+                      "templateHash": "14924009146925222912"
                     }
                   },
                   "parameters": {
@@ -7810,8 +7810,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "5976384511631180712"
+              "version": "0.36.1.42791",
+              "templateHash": "13103913196195177238"
             }
           },
           "parameters": {
@@ -7944,8 +7944,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "1485195521031446527"
+                      "version": "0.36.1.42791",
+                      "templateHash": "2081790969818493031"
                     },
                     "description": "Creates an Azure Function in an existing Azure App Service plan."
                   },
@@ -8152,8 +8152,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "1852897590455041296"
+                              "version": "0.36.1.42791",
+                              "templateHash": "17297314312801200043"
                             },
                             "description": "Creates an Azure App Service in an existing Azure App Service plan."
                           },
@@ -8379,8 +8379,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.37.4.10188",
-                                      "templateHash": "3192232430579364811"
+                                      "version": "0.36.1.42791",
+                                      "templateHash": "8872422051335608470"
                                     },
                                     "description": "Updates app settings for an Azure App Service."
                                   },
@@ -8456,8 +8456,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "7487840142945032587"
+                              "version": "0.36.1.42791",
+                              "templateHash": "4997140108958528754"
                             },
                             "description": "Creates a role assignment for a principal."
                           },
@@ -8546,8 +8546,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -8614,8 +8614,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -8682,8 +8682,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -8750,8 +8750,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -8818,8 +8818,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -8883,8 +8883,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "2705323600886100029"
+                      "version": "0.36.1.42791",
+                      "templateHash": "13097350302282890335"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -9009,8 +9009,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "5976384511631180712"
+              "version": "0.36.1.42791",
+              "templateHash": "13103913196195177238"
             }
           },
           "parameters": {
@@ -9143,8 +9143,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "1485195521031446527"
+                      "version": "0.36.1.42791",
+                      "templateHash": "2081790969818493031"
                     },
                     "description": "Creates an Azure Function in an existing Azure App Service plan."
                   },
@@ -9351,8 +9351,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "1852897590455041296"
+                              "version": "0.36.1.42791",
+                              "templateHash": "17297314312801200043"
                             },
                             "description": "Creates an Azure App Service in an existing Azure App Service plan."
                           },
@@ -9578,8 +9578,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.37.4.10188",
-                                      "templateHash": "3192232430579364811"
+                                      "version": "0.36.1.42791",
+                                      "templateHash": "8872422051335608470"
                                     },
                                     "description": "Updates app settings for an Azure App Service."
                                   },
@@ -9655,8 +9655,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "7487840142945032587"
+                              "version": "0.36.1.42791",
+                              "templateHash": "4997140108958528754"
                             },
                             "description": "Creates a role assignment for a principal."
                           },
@@ -9745,8 +9745,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -9813,8 +9813,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -9881,8 +9881,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -9949,8 +9949,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -10017,8 +10017,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "7487840142945032587"
+                      "version": "0.36.1.42791",
+                      "templateHash": "4997140108958528754"
                     },
                     "description": "Creates a role assignment for a principal."
                   },
@@ -10082,8 +10082,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "2705323600886100029"
+                      "version": "0.36.1.42791",
+                      "templateHash": "13097350302282890335"
                     },
                     "description": "Assigns an Azure Key Vault access policy."
                   },
@@ -10189,8 +10189,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "10763707742517041475"
+              "version": "0.36.1.42791",
+              "templateHash": "5396502874055092713"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -10344,8 +10344,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "10763707742517041475"
+              "version": "0.36.1.42791",
+              "templateHash": "5396502874055092713"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -10502,8 +10502,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "4572715429894847750"
+              "version": "0.36.1.42791",
+              "templateHash": "8223498772551098397"
             }
           },
           "parameters": {
@@ -10632,8 +10632,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "14532351410692526193"
+              "version": "0.36.1.42791",
+              "templateHash": "14433511087095141274"
             },
             "description": "Creates an Azure storage account."
           },
@@ -10850,8 +10850,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "7487840142945032587"
+              "version": "0.36.1.42791",
+              "templateHash": "4997140108958528754"
             },
             "description": "Creates a role assignment for a principal."
           },
@@ -10917,8 +10917,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "7487840142945032587"
+              "version": "0.36.1.42791",
+              "templateHash": "4997140108958528754"
             },
             "description": "Creates a role assignment for a principal."
           },
@@ -10984,8 +10984,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "7487840142945032587"
+              "version": "0.36.1.42791",
+              "templateHash": "4997140108958528754"
             },
             "description": "Creates a role assignment for a principal."
           },
@@ -11054,8 +11054,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "7487840142945032587"
+              "version": "0.36.1.42791",
+              "templateHash": "4997140108958528754"
             },
             "description": "Creates a role assignment for a principal."
           },
@@ -11135,8 +11135,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "14504987513843430113"
+              "version": "0.36.1.42791",
+              "templateHash": "7527931742843464990"
             }
           },
           "parameters": {
@@ -11273,8 +11273,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "5562072067489549766"
+              "version": "0.36.1.42791",
+              "templateHash": "7556565821952147924"
             }
           },
           "parameters": {


### PR DESCRIPTION
## Purpose
this is fix to:https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/issues/1907

This pull request updates the infrastructure deployment configuration to improve flexibility and maintain consistency across environments. The main change is to make the deployment location configurable instead of hardcoding it, and to ensure that the Bicep and generated ARM templates (`main.bicep` and `main.json`) are in sync.

Key changes include:

**Parameterization and Configuration Improvements**
- Changed the `solutionLocation` parameter in both `main.bicep` and the generated `main.json` from a hardcoded value (`eastus2`) to use the configurable `location` parameter, allowing deployments to target different Azure regions more easily. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L385-R385) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1215-R1215)

**Template Synchronization and Versioning**
- Regenerated the `infra/main.json` ARM template to reflect the updated Bicep source, including changes to the Bicep compiler version and template hashes throughout the file. This ensures the JSON output matches the latest Bicep source and configuration. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L7-R8) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L969-R970) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1061-R1062) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1233-R1234) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1462-R1463) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1564-R1565) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1723-R1724) [[8]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1875-R1876) [[9]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1945-R1946) [[10]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2016-R2017) [[11]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2087-R2088) [[12]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2162-R2163) [[13]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2311-R2312) [[14]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2389-R2390) [[15]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2558-R2559) [[16]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2669-R2670) [[17]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2792-R2793) [[18]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3019-R3020) [[19]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3096-R3097) [[20]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3164-R3165) [[21]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3232-R3233) [[22]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3300-R3301) [[23]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3365-R3366) [[24]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3440-R3441) [[25]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3553-R3554) [[26]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3676-R3677) [[27]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3903-R3904) [[28]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3980-R3981) [[29]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4048-R4049) [[30]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4116-R4117) [[31]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4184-R4185)
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
