### PR TITLE
fix: Simplify allowed values for hosting plan SKU in Bicep and JSON t…

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -35,18 +35,10 @@ var hostingPlanName string = 'asp-${solutionSuffix}'
 
 @description('Optional. The pricing tier for the App Service plan.')
 @allowed([
-  'F1'
-  'D1'
-  'B1'
   'B2'
   'B3'
-  'S1'
   'S2'
   'S3'
-  'P1'
-  'P2'
-  'P3'
-  'P4'
 ])
 param hostingPlanSku string = 'B3'
 

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "7004073046163258445"
+      "templateHash": "14151002700383033945"
     }
   },
   "parameters": {
@@ -48,18 +48,10 @@
       "type": "string",
       "defaultValue": "B3",
       "allowedValues": [
-        "F1",
-        "D1",
-        "B1",
         "B2",
         "B3",
-        "S1",
         "S2",
-        "S3",
-        "P1",
-        "P2",
-        "P3",
-        "P4"
+        "S3"
       ],
       "metadata": {
         "description": "Optional. The pricing tier for the App Service plan."
@@ -55436,9 +55428,9 @@
         }
       },
       "dependsOn": [
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageFile)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageFile)]",
         "managedIdentityModule",
         "network"
       ]


### PR DESCRIPTION
## Purpose
This pull request updates the allowed pricing tiers for the App Service plan in both the Bicep (`main.bicep`) and generated ARM template (`main.json`), removing lower and premium tiers. It also makes a minor change to the resource dependency order in the ARM template.

Pricing tier restrictions:

* Removed support for the following App Service plan SKUs: `F1`, `D1`, `B1`, `S1`, `P1`, `P2`, `P3`, and `P4`. Now only `B2`, `B3`, `S2`, and `S3` are allowed in both `main.bicep` and `main.json`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
