### PR TITLE
fix: Read Aloud audio playback stops when switching to another section

### DIFF
--- a/code/frontend/src/components/Answer/Answer.tsx
+++ b/code/frontend/src/components/Answer/Answer.tsx
@@ -129,7 +129,6 @@ export const Answer = ({
     }
   }, [isActive, synthesizer]);
 
-  // Cleanup on unmount
   useEffect(() => {
     return () => {
       if (isSpeaking) {

--- a/code/frontend/src/pages/chat/Chat.tsx
+++ b/code/frontend/src/pages/chat/Chat.tsx
@@ -38,7 +38,7 @@ const [ASSISTANT, TOOL, ERROR] = ["assistant", "tool", "error"];
 const Chat = () => {
   const lastQuestionRef = useRef<string>("");
   const chatMessageStreamEnd = useRef<HTMLDivElement | null>(null);
-  const audioStopRef = useRef<(() => void) | null>(null); // Ref to hold audio stop function
+  const audioStopRef = useRef<(() => void) | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isGenerating, setIsGenerating] = useState<boolean>(false);  // Add this state
   const [showLoadingMessage, setShowLoadingMessage] = useState<boolean>(false);
@@ -304,7 +304,7 @@ const Chat = () => {
   };
 
   const clearChat = () => {
-    audioStopRef.current?.(); // Stop audio immediately
+    audioStopRef.current?.();
     lastQuestionRef.current = "";
     setActiveCitation(undefined);
     setAnswers([]);
@@ -391,7 +391,6 @@ const Chat = () => {
   const handleSpeech = (index: number, status: string, stopAudioFn?: () => void) => {
     if (status != "pause") setActiveCardIndex(index);
     setIsTextToSpeachActive(status == "speak" ? true : false);
-    // Store the stop function when audio starts playing
     if (status == "speak" && stopAudioFn) {
       audioStopRef.current = stopAudioFn;
     }
@@ -431,15 +430,13 @@ const Chat = () => {
       return;
     }
 
-    // Stop audio only when switching to a different conversation
     if (id !== selectedConvId) {
-      audioStopRef.current?.(); // Stop audio immediately
-      setActiveCardIndex(null); // Stop audio for all conversation switches
+      audioStopRef.current?.();
+      setActiveCardIndex(null);
     }
 
     const messages = getMessagesByConvId(id);
     if (messages.length === 0) {
-      // For uncached: clear answers immediately to unmount components before fetch
       setAnswers([]);
       setFetchingConvMessages(true);
       const responseMessages = await historyRead(id);
@@ -447,11 +444,9 @@ const Chat = () => {
       setMessagesByConvId(id, responseMessages);
       setFetchingConvMessages(false);
     } else {
-      // For cached: just update answers
       setAnswers(messages);
     }
 
-    // Update selected conversation ID after loading messages
     if (id !== selectedConvId) {
       setSelectedConvId(id);
     }
@@ -498,7 +493,7 @@ const Chat = () => {
     );
     setChatHistory(tempChatHistory);
     if (id === selectedConvId) {
-      audioStopRef.current?.(); // Stop audio when deleting current conversation
+      audioStopRef.current?.();
       lastQuestionRef.current = "";
       setActiveCitation(undefined);
       setAnswers([]);


### PR DESCRIPTION
## Purpose

This pull request introduces improvements to the chat and answer components, primarily focusing on better management of text-to-speech audio playback. The changes ensure that audio is properly stopped when switching conversations, clearing the chat, or when a new speech playback is triggered. These updates help prevent overlapping audio and improve the user experience during conversation navigation.

**Audio Playback Management:**

* Added an `audioStopRef` to `Chat.tsx` to centrally manage stopping of text-to-speech audio across conversation changes and chat clearing.
* Ensured that audio playback is stopped when clearing the chat, switching conversations, or resetting the chat history. [[1]](diffhunk://#diff-cba35424cfd64b7e93ef230c603da35cf0ae6e0f3666ae12d7fd175ed98f5665R307-R313) [[2]](diffhunk://#diff-cba35424cfd64b7e93ef230c603da35cf0ae6e0f3666ae12d7fd175ed98f5665R432-R440) [[3]](diffhunk://#diff-cba35424cfd64b7e93ef230c603da35cf0ae6e0f3666ae12d7fd175ed98f5665R496)

**Text-to-Speech Integration:**

* Updated the `handleSpeech` and `onSpeak` logic to pass a `resetSpeech` function, allowing the parent chat component to control when audio should be stopped. [[1]](diffhunk://#diff-ff727ce8c48be64276da66d646d52c40b29fa1bf8f5d450b5320863bf8943064L224-R232) [[2]](diffhunk://#diff-ff727ce8c48be64276da66d646d52c40b29fa1bf8f5d450b5320863bf8943064L241-R249) [[3]](diffhunk://#diff-cba35424cfd64b7e93ef230c603da35cf0ae6e0f3666ae12d7fd175ed98f5665L388-R396)
* Added a cleanup effect in the `Answer` component to stop speech playback when the component unmounts, preventing lingering audio.

**Conversation State Handling:**

* Improved state resets for `activeCardIndex` and `answers` when switching or clearing conversations to maintain UI consistency and avoid mismatches between audio and displayed messages. [[1]](diffhunk://#diff-cba35424cfd64b7e93ef230c603da35cf0ae6e0f3666ae12d7fd175ed98f5665R307-R313) [[2]](diffhunk://#diff-cba35424cfd64b7e93ef230c603da35cf0ae6e0f3666ae12d7fd175ed98f5665R432-R440) [[3]](diffhunk://#diff-cba35424cfd64b7e93ef230c603da35cf0ae6e0f3666ae12d7fd175ed98f5665R449-R452)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

