### PR TITLE
test: Correct account URL assertion in TestCreateQueueClient - fix CodeQL

### DIFF
--- a/code/tests/utilities/helpers/test_azure_blob_storage_client.py
+++ b/code/tests/utilities/helpers/test_azure_blob_storage_client.py
@@ -89,7 +89,7 @@ class TestCreateQueueClient:
         call_kwargs = mock_queue_client_class.call_args[1]
         assert call_kwargs['queue_name'] == "test-queue"
         assert call_kwargs['credential'] == mock_credential
-        assert "teststorageaccount.queue.core.windows.net" in call_kwargs['account_url']
+        assert call_kwargs['account_url'] == "https://teststorageaccount.queue.core.windows.net/"
 
 
 class TestAzureBlobStorageClientInitialization:


### PR DESCRIPTION
## Purpose
This pull request makes a minor adjustment to a test assertion in the Azure Blob Storage client tests to check for the exact account URL string instead of a substring.

* Test assertion updated to require the full expected `account_url` value, improving test accuracy in `test_create_queue_client_with_rbac` in `test_azure_blob_storage_client.py`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No
