### PR TITLE
fix: Fix for Repeated Citation bug

### DIFF
--- a/code/frontend/src/components/Answer/AnswerParser.tsx
+++ b/code/frontend/src/components/Answer/AnswerParser.tsx
@@ -39,7 +39,7 @@ export function parseAnswer(answer: AskResponse): ParsedAnswer {
         }
     })
 
-    answerText = answerText.replace(/(\s*\^(\d+)\^\s*)(?:\s*\^\2\^\s*)+/g, " ^$2^ ");
+    answerText = answerText.replace(/([ \t]*\^(\d+)\^[ \t]*)(?:[ \t]*\^\2\^[ \t]*)+/g, " ^$2^ ");
 
     return {
         citations: filteredCitations,


### PR DESCRIPTION
## Purpose
This pull request makes a targeted update to the answer parsing logic, specifically improving how duplicate citation markers are handled in answer text.

- Answer formatting improvement:
  * In `AnswerParser.tsx`, added a regular expression replacement to collapse consecutive duplicate citation markers (e.g., `^1^ ^1^`) into a single instance, resulting in cleaner and more readable answer text.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
Before Fix:
<img width="1341" height="457" alt="image" src="https://github.com/user-attachments/assets/27939725-3199-481b-bd4e-05343a2d7645" />

After Fix:
<img width="1250" height="402" alt="image" src="https://github.com/user-attachments/assets/bf49a58c-defc-477a-bea2-44bad1eb6db7" />

