### PR TITLE
fix: add input validation for offset/limit to prevent query injection in CosmosDB

### DIFF
--- a/code/backend/api/chat_history.py
+++ b/code/backend/api/chat_history.py
@@ -55,7 +55,12 @@ async def list_conversations():
         return jsonify({"error": "Chat history is not available"}), 400
 
     try:
-        offset = request.args.get("offset", 0)
+        try:
+            offset = int(request.args.get("offset", 0))
+        except (ValueError, TypeError):
+            return jsonify({"error": "offset must be a valid integer"}), 400
+        if offset < 0:
+            return jsonify({"error": "offset must be non-negative"}), 400
         authenticated_user = get_authenticated_user_details(
             request_headers=request.headers
         )

--- a/code/backend/batch/utilities/chat_history/cosmosdb.py
+++ b/code/backend/batch/utilities/chat_history/cosmosdb.py
@@ -122,8 +122,12 @@ class CosmosConversationClient(DatabaseClientBase):
 
     async def get_conversations(self, user_id, limit, sort_order="DESC", offset=0):
         parameters = [{"name": "@userId", "value": user_id}]
+        if sort_order not in ("ASC", "DESC"):
+            sort_order = "DESC"
         query = f"SELECT * FROM c where c.userId = @userId and c.type='conversation' order by c.updatedAt {sort_order}"
         if limit is not None:
+            offset = int(offset)
+            limit = int(limit)
             query += f" offset {offset} limit {limit}"
 
         conversations = []


### PR DESCRIPTION
## Summary
  - Added input validation and type casting for `offset` query parameter in `/history/list` API endpoint to prevent invalid or malicious values from reaching the database layer
  - Added whitelist validation for `sort_order` parameter in `CosmosConversationClient.get_conversations()` to only allow `ASC` or `DESC`       
  - Added explicit `int()` casting for `offset` and `limit` before interpolation into CosmosDB SQL query string

## Problem
The `offset` and `limit` parameters in the CosmosDB query were directly interpolated into the SQL query using f-strings without any validation   or parameterization. The `offset` value from the API request was passed through without type conversion, potentially allowing query injection.

## Changes
  **`code/backend/api/chat_history.py`**
  - Added `try/except` block to validate `offset` as a valid integer
  - Added range check to reject negative values
  - Returns `400` error for invalid input

  **`code/backend/batch/utilities/chat_history/cosmosdb.py`**
  - Added whitelist check for `sort_order` (only `ASC`/`DESC` allowed, defaults to `DESC`)
  - Added `int()` casting for `offset` and `limit` before query interpolation