### PR TITLE
fix: update frontend packaging script execution to use bash

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -70,7 +70,7 @@ services:
           continueOnError: false
         posix:
           shell: sh
-          run: ./scripts/package_frontend.sh
+          run: bash ./scripts/package_frontend.sh
           interactive: true
           continueOnError: false
 


### PR DESCRIPTION
## Purpose
This pull request makes a minor update to the frontend packaging script in the Azure pipeline configuration. The script is now explicitly run with `bash` instead of relying on the default shell.

* Changed the `run` command in the `azure.yaml` pipeline to use `bash ./scripts/package_frontend.sh` for better shell compatibility.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
