### PR TITLE
feat: update managed identity configurations and enhance web security

### DIFF
--- a/extensions/teams/infra/azure.bicep
+++ b/extensions/teams/infra/azure.bicep
@@ -44,6 +44,9 @@ resource webApp 'Microsoft.Web/sites@2024-04-01' = {
   kind: 'app'
   location: location
   name: webAppName
+  identity: {
+    type: 'SystemAssigned'
+  }
   properties: {
     serverFarmId: serverfarm.id
     httpsOnly: true

--- a/infra/modules/app/eventgrid.bicep
+++ b/infra/modules/app/eventgrid.bicep
@@ -53,11 +53,17 @@ module avmEventGridSystemTopic 'br/public:avm/res/event-grid/system-topic:0.6.4'
     eventSubscriptions: [
       {
         name: name
-        destination: {
-          endpointType: 'StorageQueue'
-          properties: {
-            queueName: queueName
-            resourceId: storageAccountId
+        deliveryWithResourceIdentity: {
+          identity: {
+            type: 'UserAssigned'
+            userAssignedIdentity: userAssignedResourceId
+          }
+          destination: {
+            endpointType: 'StorageQueue'
+            properties: {
+              queueName: queueName
+              resourceId: storageAccountId
+            }
           }
         }
         eventDeliverySchema: 'EventGridSchema'

--- a/infra/modules/core/host/appservice.bicep
+++ b/infra/modules/core/host/appservice.bicep
@@ -37,8 +37,10 @@ param clientAffinityEnabled bool = true
 param appServiceEnvironmentResourceId string?
 
 import { managedIdentityAllType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
-@description('Optional. The managed identity definition for this resource.')
-param managedIdentities managedIdentityAllType?
+@description('Optional. The managed identity definition for this resource. Defaults to system-assigned managed identity.')
+param managedIdentities managedIdentityAllType = {
+  systemAssigned: true
+}
 
 @description('Optional. The resource ID of the assigned identity to be used to access a key vault with.')
 param keyVaultAccessIdentityResourceId string?

--- a/infra/modules/core/host/web-sites.config.bicep
+++ b/infra/modules/core/host/web-sites.config.bicep
@@ -58,7 +58,16 @@ var appInsightsValues = !empty(applicationInsightResourceId)
     }
   : {}
 
-var expandedProperties = union(currentAppSettings, properties, azureWebJobsValues, appInsightsValues)
+// Ensure FTPS enforcement and other security settings for 'web' config
+var webConfigSecurityDefaults = name == 'web'
+  ? {
+      ftpsState: 'FtpsOnly'
+      minTlsVersion: '1.3'
+      httpsOnly: true
+    }
+  : {}
+
+var expandedProperties = union(currentAppSettings, properties, azureWebJobsValues, appInsightsValues, webConfigSecurityDefaults)
 
 resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing = if (!empty(applicationInsightResourceId)) {
   name: last(split(applicationInsightResourceId!, '/'))


### PR DESCRIPTION
## Purpose

This pull request introduces several improvements to the Azure infrastructure Bicep modules, with a focus on enhancing security defaults and managed identity configurations. The most significant changes include enforcing secure defaults for web applications, setting system-assigned managed identities by default, and improving identity assignment for Event Grid subscriptions.

**Security and Configuration Enhancements:**

* Enforced FTPS-only, minimum TLS version 1.3, and HTTPS-only settings by default for web app configurations in `web-sites.config.bicep` to improve security posture.

**Managed Identity Improvements:**

* Changed the `managedIdentities` parameter in `host/appservice.bicep` to default to a system-assigned managed identity, simplifying identity management for app services.
* Added a `SystemAssigned` identity to the `Microsoft.Web/sites` resource in `azure.bicep`, ensuring all web apps have a managed identity by default.

**Event Grid Enhancements:**

* Updated the Event Grid System Topic module in `eventgrid.bicep` to support delivery with a user-assigned identity, allowing for more flexible and secure resource access in event subscriptions.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No
