### PR TITLE
fix: prevent federated SP token expiry in post-deployment PostgreSQL setup

### DIFF
--- a/.github/workflows/import-sample-data-postgresql.yml
+++ b/.github/workflows/import-sample-data-postgresql.yml
@@ -143,11 +143,6 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Upgrade Azure CLI and install extensions
-        run: |
-          az upgrade --yes --all
-          az extension add --name rdbms-connect --upgrade --yes || true
-
       - name: Discover PostgreSQL Server from Resource Group
         env:
           INPUT_RESOURCE_GROUP_NAME: ${{ inputs.RESOURCE_GROUP_NAME }}

--- a/scripts/data_scripts/setup_postgres_tables.py
+++ b/scripts/data_scripts/setup_postgres_tables.py
@@ -2,6 +2,19 @@
 
 Usage:
     python setup_postgres_tables.py <server_fqdn> <user>
+
+Authentication:
+    The script authenticates to PostgreSQL using a Microsoft Entra ID access
+    token (the ``ossrdbms-aad`` resource). It resolves the token in this order:
+
+    1. ``PG_ACCESS_TOKEN`` environment variable, if set. The post-deployment
+       wrapper scripts (``post_deployment_setup.sh`` / ``.ps1``) acquire the
+       token via ``az account get-access-token`` immediately before invoking
+       this script and export it as ``PG_ACCESS_TOKEN`` to avoid token expiry
+       (especially for federated service principals where ``DefaultAzureCredential``
+       may fail).
+    2. Fallback: ``azure.identity.DefaultAzureCredential`` is used to acquire
+       a token in-process when ``PG_ACCESS_TOKEN`` is not set.
 """
 
 import os
@@ -25,10 +38,13 @@ if not token:
         "https://ossrdbms-aad.database.windows.net/.default"
     ).token
 
-conn_string = "host={0} user={1} dbname={2} password={3} sslmode=require".format(
-    host, user, dbname, token
+conn = psycopg2.connect(
+    host=host,
+    user=user,
+    dbname=dbname,
+    password=token,
+    sslmode="require",
 )
-conn = psycopg2.connect(conn_string)
 cursor = conn.cursor()
 
 # Drop and recreate the conversations table

--- a/scripts/data_scripts/setup_postgres_tables.py
+++ b/scripts/data_scripts/setup_postgres_tables.py
@@ -2,13 +2,11 @@
 
 Usage:
     python setup_postgres_tables.py <server_fqdn> <user>
-
-Authenticates using DefaultAzureCredential (requires 'az login').
 """
 
+import os
 import sys
 import psycopg2
-from azure.identity import DefaultAzureCredential
 
 if len(sys.argv) != 3:
     print("Usage: python setup_postgres_tables.py <server_fqdn> <user>")
@@ -18,12 +16,17 @@ host = sys.argv[1]
 user = sys.argv[2]
 dbname = "postgres"
 
-# Acquire the access token
-cred = DefaultAzureCredential()
-access_token = cred.get_token("https://ossrdbms-aad.database.windows.net/.default")
+token = os.environ.get("PG_ACCESS_TOKEN")
+if not token:
+    from azure.identity import DefaultAzureCredential
+
+    cred = DefaultAzureCredential()
+    token = cred.get_token(
+        "https://ossrdbms-aad.database.windows.net/.default"
+    ).token
 
 conn_string = "host={0} user={1} dbname={2} password={3} sslmode=require".format(
-    host, user, dbname, access_token.token
+    host, user, dbname, token
 )
 conn = psycopg2.connect(conn_string)
 cursor = conn.cursor()

--- a/scripts/post_deployment_setup.ps1
+++ b/scripts/post_deployment_setup.ps1
@@ -27,9 +27,6 @@ Write-Host " Post-Deployment Setup"
 Write-Host " Resource Group: $ResourceGroupName"
 Write-Host "=============================================="
 
-$env:PG_ACCESS_TOKEN = az account get-access-token `
-    --resource "https://ossrdbms-aad.database.windows.net" `
-    --query accessToken -o tsv 2>$null
 
 # Remove rdbms-connect extension if present (it conflicts with built-in admin commands)
 az extension remove --name rdbms-connect 2>$null | Out-Null

--- a/scripts/post_deployment_setup.ps1
+++ b/scripts/post_deployment_setup.ps1
@@ -27,6 +27,10 @@ Write-Host " Post-Deployment Setup"
 Write-Host " Resource Group: $ResourceGroupName"
 Write-Host "=============================================="
 
+$env:PG_ACCESS_TOKEN = az account get-access-token `
+    --resource "https://ossrdbms-aad.database.windows.net" `
+    --query accessToken -o tsv 2>$null
+
 # Remove rdbms-connect extension if present (it conflicts with built-in admin commands)
 az extension remove --name rdbms-connect 2>$null | Out-Null
 
@@ -315,12 +319,27 @@ else {
             pip install --user -r $requirementsFile 2>&1 | Out-Null
         }
 
+        if ([string]::IsNullOrEmpty($env:PG_ACCESS_TOKEN)) {
+            Write-Host "✓ Acquiring PostgreSQL access token..."
+            $env:PG_ACCESS_TOKEN = az account get-access-token `
+                --resource "https://ossrdbms-aad.database.windows.net" `
+                --query accessToken -o tsv 2>$null
+            if ([string]::IsNullOrEmpty($env:PG_ACCESS_TOKEN)) {
+                Write-Warning "Failed to acquire PostgreSQL access token via az CLI. Falling back to DefaultAzureCredential inside Python (may fail for federated SPs)."
+            }
+        }
+
         Write-Host "✓ Creating tables..."
         $pythonScript = Join-Path $scriptDir "data_scripts" "setup_postgres_tables.py"
-        python $pythonScript $serverFqdn $currentUserUpn
+        try {
+            python $pythonScript $serverFqdn $currentUserUpn
 
-        if ($LASTEXITCODE -ne 0) {
-            Write-Error "✗ Failed to create PostgreSQL tables."
+            if ($LASTEXITCODE -ne 0) {
+                Write-Error "✗ Failed to create PostgreSQL tables."
+            }
+        }
+        finally {
+            Remove-Item Env:PG_ACCESS_TOKEN -ErrorAction SilentlyContinue
         }
     }
     finally {

--- a/scripts/post_deployment_setup.sh
+++ b/scripts/post_deployment_setup.sh
@@ -33,11 +33,6 @@ echo "=============================================="
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -W 2>/dev/null || pwd)"
 
-PG_ACCESS_TOKEN=$(az account get-access-token \
-    --resource "https://ossrdbms-aad.database.windows.net" \
-    --query accessToken -o tsv 2>/dev/null || true)
-export PG_ACCESS_TOKEN
-
 # Remove rdbms-connect extension if present (it conflicts with built-in admin commands)
 az extension remove --name rdbms-connect > /dev/null 2>&1 || true
 

--- a/scripts/post_deployment_setup.sh
+++ b/scripts/post_deployment_setup.sh
@@ -33,6 +33,11 @@ echo "=============================================="
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -W 2>/dev/null || pwd)"
 
+PG_ACCESS_TOKEN=$(az account get-access-token \
+    --resource "https://ossrdbms-aad.database.windows.net" \
+    --query accessToken -o tsv 2>/dev/null || true)
+export PG_ACCESS_TOKEN
+
 # Remove rdbms-connect extension if present (it conflicts with built-in admin commands)
 az extension remove --name rdbms-connect > /dev/null 2>&1 || true
 
@@ -328,8 +333,21 @@ else
         pip install --user -r "$REQUIREMENTS_FILE" > /dev/null 2>&1 || echo "⚠ WARNING: pip install failed. Continuing anyway..."
     fi
 
+    if [ -z "$PG_ACCESS_TOKEN" ]; then
+        echo "✓ Acquiring PostgreSQL access token..."
+        PG_ACCESS_TOKEN=$(az account get-access-token \
+            --resource "https://ossrdbms-aad.database.windows.net" \
+            --query accessToken -o tsv 2>/dev/null || true)
+        export PG_ACCESS_TOKEN
+        if [ -z "$PG_ACCESS_TOKEN" ]; then
+            echo "⚠ WARNING: Failed to acquire PostgreSQL access token via az CLI."
+            echo "  Falling back to DefaultAzureCredential inside Python (may fail for federated SPs)."
+        fi
+    fi
+
     echo "✓ Creating tables..."
     python "$SCRIPT_DIR/data_scripts/setup_postgres_tables.py" "$SERVER_FQDN" "$CURRENT_USER_UPN"
+    unset PG_ACCESS_TOKEN
     echo "✓ PostgreSQL table creation completed."
 fi
 

--- a/tests/e2e-test/pages/adminPage.py
+++ b/tests/e2e-test/pages/adminPage.py
@@ -3,10 +3,10 @@ from base.base import BasePage
 
 class AdminPage(BasePage):
     ADMIN_PAGE_TITLE = "//h1[contains(., 'Chat with your data Solution Accelerator')]"
-    INGEST_DATA_TAB = "//span[text()='Ingest Data']"
-    EXPLORE_DATA_TAB = "//span[text()='Explore Data']"
-    DELETE_DATA_TAB = "//span[text()='Delete Data']"
-    CONFIGURATION_TAB = "//span[text()='Configuration']"
+    INGEST_DATA_TAB = "//a[normalize-space()='Ingest Data']"
+    EXPLORE_DATA_TAB = "//a[normalize-space()='Explore Data']"
+    DELETE_DATA_TAB = "//a[normalize-space()='Delete Data']"
+    CONFIGURATION_TAB = "//a[normalize-space()='Configuration']"
     BROWSE_FILES_BUTTON = "//button[normalize-space()='Browse files']"
     UPLOAD_SUCCESS_MESSAGE = "//div[@data-testid='stAlertContentSuccess']//p"
     REPROCESS_ALL_DOCUMENTS_BUTTON = "//p[contains(text(),'Reprocess all documents')]"


### PR DESCRIPTION
## Purpose
This pull request improves the way PostgreSQL access tokens are acquired and used during post-deployment setup, making the process more robust and compatible with different authentication scenarios. The main changes ensure that an access token is obtained via the Azure CLI if possible and passed to the Python setup script through an environment variable, with a fallback to `DefaultAzureCredential` in Python if necessary.

**Improvements to PostgreSQL access token handling:**

* The PowerShell (`post_deployment_setup.ps1`) and Bash (`post_deployment_setup.sh`) scripts now attempt to acquire a PostgreSQL access token using the Azure CLI (`az account get-access-token`) and set it as the `PG_ACCESS_TOKEN` environment variable before running the Python setup script. If the token cannot be acquired, a warning is displayed, and the system falls back to using `DefaultAzureCredential` inside Python. The environment variable is cleaned up after use. [[1]](diffhunk://#diff-b9adbaf0c34a6878773ba79750a2c84a98fb36256cfa6edcaf8ee25c9b803601R30-R33) [[2]](diffhunk://#diff-b9adbaf0c34a6878773ba79750a2c84a98fb36256cfa6edcaf8ee25c9b803601R322-R344) [[3]](diffhunk://#diff-06ae9b2bc4fbc23989501d97105b2cfadd4854afc782067beff81b7637576133R36-R40) [[4]](diffhunk://#diff-06ae9b2bc4fbc23989501d97105b2cfadd4854afc782067beff81b7637576133R336-R350)

* The Python script `setup_postgres_tables.py` is updated to first check for the `PG_ACCESS_TOKEN` environment variable and use it if present. If not, it falls back to acquiring a token using `DefaultAzureCredential`. This improves compatibility with federated service principals and other authentication scenarios. [[1]](diffhunk://#diff-3fb499aa797d6d884d822692625952b680a1d77dbb2a8185c6e92dcffa7b0569L5-L11) [[2]](diffhunk://#diff-3fb499aa797d6d884d822692625952b680a1d77dbb2a8185c6e92dcffa7b0569L21-R29)

**Workflow simplification:**

* The Azure CLI upgrade and extension installation step is removed from the GitHub Actions workflow, as it is no longer required for token acquisition.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
