### PR TITLE
docs: Add Bicep CLI (v0.33.0+) to local deployment prerequisites

### DIFF
--- a/docs/LOCAL_DEPLOYMENT.md
+++ b/docs/LOCAL_DEPLOYMENT.md
@@ -129,6 +129,7 @@ Select one of the following options to set up your Chat with your Data local dep
 - [Python 3.11](https://www.python.org/downloads/release/python-3119/)
 - [Node.js LTS](https://nodejs.org/en)
 - [Azure Developer CLI](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd) <small>(v1.18.0+)</small>
+- [Bicep CLI](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install) <small>(v0.33.0+)</small>
 - [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local)
 - [Git](https://git-scm.com/downloads)
 - [PowerShell 7.0+](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell)

--- a/docs/NON_DEVCONTAINER_SETUP.md
+++ b/docs/NON_DEVCONTAINER_SETUP.md
@@ -14,6 +14,7 @@ If you are unable to run this accelerator using a DevContainer or in GitHub Code
 - [Python 3.11](https://www.python.org/downloads/release/python-3119/)
 - [Node.js LTS](https://nodejs.org/en)
 - [Azure Developer CLI](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd) <small>(v1.18.0+)</small>
+- [Bicep CLI](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install) <small>(v0.33.0+)</small>
 - [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local)
 
 ## Setup


### PR DESCRIPTION
## Summary

This PR adds the **Bicep CLI** (`v0.33.0+`) as a prerequisite to the local deployment guide of this Generic Solution Accelerator.

The infrastructure-as-code templates in this repository (under `infra/`) require a recent version of the Bicep CLI to compile and deploy successfully via `azd up` / `az deployment`. Without the minimum supported version, users running the deployment locally encounter cryptic compilation errors due to unsupported syntax/features in older Bicep releases.

## Changes

- Added a Bicep CLI (v0.33.0+) entry to the prerequisites list of the local deployment guide, following the **exact format and style** of the existing prerequisite entries (azd, Python, Node.js, etc.) in this repo.

## Why

- Aligns the local deployment guide with the actual minimum Bicep version required by the Bicep templates in this repository.
- Prevents first-run failures for new users provisioning the accelerator from a fresh local environment.
- Brings this accelerator in line with the standard prerequisite set being rolled out across all CSA Generic Solution Accelerators (GSAs).

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Verified the Markdown renders correctly on GitHub (entry appears in the prerequisites list, link resolves to the official Microsoft Learn install page).
- [x] Confirmed the change is scoped to documentation only — no code, infrastructure, or configuration paths are modified.

## Checklist

- [x] My change follows the existing documentation style and formatting of the repository.
- [x] I have performed a self-review of my changes.
- [x] No new warnings, broken links, or formatting issues are introduced.
- [x] No code, configuration, or behavior changes are included in this PR (docs-only).

## Related Work Item

- AB#42634 — `[ALL GSA's] - Add bicep version to the local deployment guide`
