### PR TITLE
fix: fixed ServiceUnavailable errors in Post Deployment Script when executed through Service Principle

### DIFF
--- a/.github/workflows/job-post-deployment-setup.yml
+++ b/.github/workflows/job-post-deployment-setup.yml
@@ -43,40 +43,7 @@ jobs:
         run: |
           pip install psycopg2-binary azure-identity
 
-      - name: Run Post-Deployment Setup (Attempt 1)
-        id: setup1
-        shell: bash
-        env:
-          RESOURCE_GROUP: ${{ inputs.RESOURCE_GROUP_NAME }}
-        run: |
-          chmod +x scripts/post_deployment_setup.sh
-          bash scripts/post_deployment_setup.sh "$RESOURCE_GROUP"
-        continue-on-error: true
-
-      - name: Wait 20 seconds before retry
-        if: ${{ steps.setup1.outcome == 'failure' }}
-        shell: bash
-        run: sleep 20s
-
-      - name: Run Post-Deployment Setup (Attempt 2)
-        id: setup2
-        if: ${{ steps.setup1.outcome == 'failure' }}
-        shell: bash
-        env:
-          RESOURCE_GROUP: ${{ inputs.RESOURCE_GROUP_NAME }}
-        run: |
-          chmod +x scripts/post_deployment_setup.sh
-          bash scripts/post_deployment_setup.sh "$RESOURCE_GROUP"
-        continue-on-error: true
-
-      - name: Wait 40 seconds before final retry
-        if: ${{ steps.setup2.outcome == 'failure' }}
-        shell: bash
-        run: sleep 40s
-
-      - name: Run Post-Deployment Setup (Attempt 3)
-        id: setup3
-        if: ${{ steps.setup2.outcome == 'failure' }}
+      - name: Run Post-Deployment Setup
         shell: bash
         env:
           RESOURCE_GROUP: ${{ inputs.RESOURCE_GROUP_NAME }}

--- a/scripts/post_deployment_setup.sh
+++ b/scripts/post_deployment_setup.sh
@@ -201,11 +201,31 @@ else
         # reduces transient "ServiceUnavailable from host runtime" failures,
         # especially under service-principal driven deployments where the host
         # may still be cold-starting after provisioning.
-        echo "Waiting for Functions host runtime to be ready..."
         SUBSCRIPTION_ID=$(az account show --query "id" -o tsv | tr -d '\r')
+
+        # Restart the function app before setting the key.
+        # After fresh provisioning, the Functions host frequently lands in a state where
+        # the ARM-proxied keystore endpoints return InternalServerError/ServiceUnavailable.
+        # This is especially common under service-principal-driven deployments because
+        # role assignments (e.g. Storage Blob Data Owner for identity-based AzureWebJobsStorage)
+        # may not have fully propagated by the time the host first booted. A restart forces
+        # the host to re-initialize against the now-valid configuration.
+        echo "✓ Restarting function app to ensure host runtime is in a clean state..."
+        az functionapp restart --name "$FUNCTION_APP_NAME" --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1 || true
+        sleep 20
+
+        # Wait for site to report Running again
+        for i in $(seq 1 20); do
+            STATE=$(az functionapp show --name "$FUNCTION_APP_NAME" --resource-group "$RESOURCE_GROUP" --query "state" -o tsv 2>/dev/null || true)
+            [ "$STATE" = "Running" ] && break
+            echo "  [${i}/20] Function app not Running after restart. Retrying in 15s..."
+            sleep 15
+        done
+
+        echo "Waiting for Functions host runtime to be ready..."
         HOST_STATUS_URI="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Web/sites/${FUNCTION_APP_NAME}/host/default/properties/status?api-version=2023-01-01"
-        HOST_MAX_RETRIES=20
-        HOST_RETRY_INTERVAL=30
+        HOST_MAX_RETRIES=30
+        HOST_RETRY_INTERVAL=20
         for i in $(seq 1 $HOST_MAX_RETRIES); do
             HOST_STATE=$(az rest --method get --uri "$HOST_STATUS_URI" --query "properties.state" -o tsv 2>/dev/null || true)
             if [ "$HOST_STATE" = "Running" ]; then
@@ -216,8 +236,11 @@ else
             sleep $HOST_RETRY_INTERVAL
         done
 
+        # Warm up the host with an HTTP probe (best-effort, ignores result).
+        curl -fsS -o /dev/null -m 30 "https://${FUNCTION_APP_NAME}.azurewebsites.net/" >/dev/null 2>&1 || true
+
         # Set the function key via REST API (with retries — the host runtime may
-        # still report transient ServiceUnavailable during early initialization).
+        # still report transient errors during early initialization).
         echo "✓ Setting function key 'ClientKey' on '${FUNCTION_APP_NAME}'..."
         URI="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Web/sites/${FUNCTION_APP_NAME}/host/default/functionKeys/clientKey?api-version=2023-01-01"
         BODY="{\"properties\":{\"name\":\"ClientKey\",\"value\":\"${FUNCTION_KEY}\"}}"
@@ -231,10 +254,16 @@ else
                 KEY_SET=true
                 break
             fi
-            # Recognize the well-known transient "ServiceUnavailable from host runtime"
-            # error and continue retrying. Other errors are also retried but logged.
-            if echo "$REST_ERR" | grep -qi "ServiceUnavailable"; then
-                echo "  [${attempt}/${KEY_MAX_RETRIES}] Host runtime returned ServiceUnavailable. Retrying in ${KEY_RETRY_INTERVAL}s..."
+            # Recognize the well-known transient "ServiceUnavailable / InternalServerError
+            # from host runtime" error and continue retrying. Other errors are also retried but logged.
+            if echo "$REST_ERR" | grep -qiE "ServiceUnavailable|InternalServerError"; then
+                echo "  [${attempt}/${KEY_MAX_RETRIES}] Host runtime transient error. Retrying in ${KEY_RETRY_INTERVAL}s..."
+                # Every 5 failed attempts, restart the function app again to nudge the host out of a bad state.
+                if [ $((attempt % 5)) -eq 0 ] && [ $attempt -lt $KEY_MAX_RETRIES ]; then
+                    echo "  → Re-restarting function app to clear stuck host state..."
+                    az functionapp restart --name "$FUNCTION_APP_NAME" --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1 || true
+                    sleep 30
+                fi
             else
                 echo "  [${attempt}/${KEY_MAX_RETRIES}] Key set failed. Retrying in ${KEY_RETRY_INTERVAL}s..."
                 echo "  $REST_ERR"
@@ -247,6 +276,14 @@ else
         else
             echo "✗ ERROR: Failed to set function key on '${FUNCTION_APP_NAME}' after ${KEY_MAX_RETRIES} attempts." >&2
             echo "  Last error: $REST_ERR" >&2
+            echo "" >&2
+            echo "  Manual workaround:" >&2
+            echo "    1. In the Azure Portal, open Function App '${FUNCTION_APP_NAME}' → Functions → App keys." >&2
+            echo "    2. Add a Host key named 'ClientKey' with the value of the 'FUNCTION-KEY' secret" >&2
+            echo "       in Key Vault '${KEY_VAULT_NAME}'." >&2
+            echo "    3. Or run:" >&2
+            echo "       az functionapp keys set --name ${FUNCTION_APP_NAME} --resource-group ${RESOURCE_GROUP} \\" >&2
+            echo "         --key-type functionKeys --key-name ClientKey --key-value <FUNCTION-KEY value>" >&2
             restore_network_access
             exit 1
         fi

--- a/scripts/post_deployment_setup.sh
+++ b/scripts/post_deployment_setup.sh
@@ -196,14 +196,34 @@ else
             sleep $RETRY_INTERVAL
         done
 
-        # Set the function key via REST API (with retries — the host runtime may not be ready yet)
-        echo "✓ Setting function key 'ClientKey' on '${FUNCTION_APP_NAME}'..."
+        # Probe the host runtime status endpoint so we don't attempt the key write
+        # before the Functions host has finished initializing. This significantly
+        # reduces transient "ServiceUnavailable from host runtime" failures,
+        # especially under service-principal driven deployments where the host
+        # may still be cold-starting after provisioning.
+        echo "Waiting for Functions host runtime to be ready..."
         SUBSCRIPTION_ID=$(az account show --query "id" -o tsv | tr -d '\r')
+        HOST_STATUS_URI="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Web/sites/${FUNCTION_APP_NAME}/host/default/properties/status?api-version=2023-01-01"
+        HOST_MAX_RETRIES=20
+        HOST_RETRY_INTERVAL=30
+        for i in $(seq 1 $HOST_MAX_RETRIES); do
+            HOST_STATE=$(az rest --method get --uri "$HOST_STATUS_URI" --query "properties.state" -o tsv 2>/dev/null || true)
+            if [ "$HOST_STATE" = "Running" ]; then
+                echo "Functions host runtime is Running."
+                break
+            fi
+            echo "  [${i}/${HOST_MAX_RETRIES}] Host runtime state: '${HOST_STATE:-unknown}'. Retrying in ${HOST_RETRY_INTERVAL}s..."
+            sleep $HOST_RETRY_INTERVAL
+        done
+
+        # Set the function key via REST API (with retries — the host runtime may
+        # still report transient ServiceUnavailable during early initialization).
+        echo "✓ Setting function key 'ClientKey' on '${FUNCTION_APP_NAME}'..."
         URI="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Web/sites/${FUNCTION_APP_NAME}/host/default/functionKeys/clientKey?api-version=2023-01-01"
         BODY="{\"properties\":{\"name\":\"ClientKey\",\"value\":\"${FUNCTION_KEY}\"}}"
 
         KEY_SET=false
-        KEY_MAX_RETRIES=5
+        KEY_MAX_RETRIES=20
         KEY_RETRY_INTERVAL=30
         for attempt in $(seq 1 $KEY_MAX_RETRIES); do
             REST_ERR=$(az rest --method put --uri "$URI" --body "$BODY" 2>&1 > /dev/null) || true
@@ -211,8 +231,14 @@ else
                 KEY_SET=true
                 break
             fi
-            echo "  [${attempt}/${KEY_MAX_RETRIES}] Host runtime not ready yet. Retrying in ${KEY_RETRY_INTERVAL}s..."
-            echo "  $REST_ERR"
+            # Recognize the well-known transient "ServiceUnavailable from host runtime"
+            # error and continue retrying. Other errors are also retried but logged.
+            if echo "$REST_ERR" | grep -qi "ServiceUnavailable"; then
+                echo "  [${attempt}/${KEY_MAX_RETRIES}] Host runtime returned ServiceUnavailable. Retrying in ${KEY_RETRY_INTERVAL}s..."
+            else
+                echo "  [${attempt}/${KEY_MAX_RETRIES}] Key set failed. Retrying in ${KEY_RETRY_INTERVAL}s..."
+                echo "  $REST_ERR"
+            fi
             sleep $KEY_RETRY_INTERVAL
         done
 
@@ -220,6 +246,7 @@ else
             echo "✓ Function key set successfully."
         else
             echo "✗ ERROR: Failed to set function key on '${FUNCTION_APP_NAME}' after ${KEY_MAX_RETRIES} attempts." >&2
+            echo "  Last error: $REST_ERR" >&2
             restore_network_access
             exit 1
         fi

--- a/scripts/post_deployment_setup.sh
+++ b/scripts/post_deployment_setup.sh
@@ -196,20 +196,12 @@ else
             sleep $RETRY_INTERVAL
         done
 
-        # Probe the host runtime status endpoint so we don't attempt the key write
-        # before the Functions host has finished initializing. This significantly
-        # reduces transient "ServiceUnavailable from host runtime" failures,
-        # especially under service-principal driven deployments where the host
-        # may still be cold-starting after provisioning.
+        # Force host re-init: identity-based AzureWebJobsStorage role assignments
+        # can land after the host's first boot, leaving the ARM-proxied keystore
+        # endpoint stuck on InternalServerError/ServiceUnavailable (most common
+        # under service-principal deployments).
         SUBSCRIPTION_ID=$(az account show --query "id" -o tsv | tr -d '\r')
 
-        # Restart the function app before setting the key.
-        # After fresh provisioning, the Functions host frequently lands in a state where
-        # the ARM-proxied keystore endpoints return InternalServerError/ServiceUnavailable.
-        # This is especially common under service-principal-driven deployments because
-        # role assignments (e.g. Storage Blob Data Owner for identity-based AzureWebJobsStorage)
-        # may not have fully propagated by the time the host first booted. A restart forces
-        # the host to re-initialize against the now-valid configuration.
         echo "✓ Restarting function app to ensure host runtime is in a clean state..."
         az functionapp restart --name "$FUNCTION_APP_NAME" --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1 || true
         sleep 20
@@ -236,11 +228,10 @@ else
             sleep $HOST_RETRY_INTERVAL
         done
 
-        # Warm up the host with an HTTP probe (best-effort, ignores result).
+        # Warm up the host (best-effort).
         curl -fsS -o /dev/null -m 30 "https://${FUNCTION_APP_NAME}.azurewebsites.net/" >/dev/null 2>&1 || true
 
-        # Set the function key via REST API (with retries — the host runtime may
-        # still report transient errors during early initialization).
+        # Set the function key via REST API (with retries — the host runtime may not be ready yet)
         echo "✓ Setting function key 'ClientKey' on '${FUNCTION_APP_NAME}'..."
         URI="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Web/sites/${FUNCTION_APP_NAME}/host/default/functionKeys/clientKey?api-version=2023-01-01"
         BODY="{\"properties\":{\"name\":\"ClientKey\",\"value\":\"${FUNCTION_KEY}\"}}"
@@ -254,11 +245,10 @@ else
                 KEY_SET=true
                 break
             fi
-            # Recognize the well-known transient "ServiceUnavailable / InternalServerError
-            # from host runtime" error and continue retrying. Other errors are also retried but logged.
+            # Treat ServiceUnavailable / InternalServerError from the host runtime as transient.
             if echo "$REST_ERR" | grep -qiE "ServiceUnavailable|InternalServerError"; then
                 echo "  [${attempt}/${KEY_MAX_RETRIES}] Host runtime transient error. Retrying in ${KEY_RETRY_INTERVAL}s..."
-                # Every 5 failed attempts, restart the function app again to nudge the host out of a bad state.
+                # Every 5 attempts, restart to nudge a stuck host.
                 if [ $((attempt % 5)) -eq 0 ] && [ $attempt -lt $KEY_MAX_RETRIES ]; then
                     echo "  → Re-restarting function app to clear stuck host state..."
                     az functionapp restart --name "$FUNCTION_APP_NAME" --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Purpose
This pull request improves the reliability and robustness of the post-deployment setup process for Azure Function Apps. The main changes include simplifying the GitHub Actions workflow by removing redundant retry logic from the workflow YAML and moving enhanced retry and recovery logic into the `post_deployment_setup.sh` script. The script now includes explicit Function App restarts, better detection and handling of transient host runtime errors, and clearer guidance for manual recovery.

**Workflow simplification:**

* The retry and wait logic for running the post-deployment setup script has been removed from `.github/workflows/job-post-deployment-setup.yml`, so the setup is now attempted only once per workflow run. All retry and recovery logic is now handled within the shell script itself.

**Post-deployment script robustness:**

* The script now explicitly restarts the Azure Function App after deployment to ensure the host runtime is in a clean state, addressing issues where role assignments may not be available on the first boot.
* After restarting, the script waits for the Function App and the Functions host runtime to report as "Running" before proceeding, improving readiness checks.
* The retry logic for setting the function key has been enhanced: the maximum number of retries has been increased, transient errors (like `ServiceUnavailable` or `InternalServerError`) are handled with additional restarts, and host restarts are triggered every 5 failed attempts to clear stuck states.
* If setting the function key ultimately fails, the script now outputs detailed manual recovery instructions for operators, including Azure Portal and CLI steps.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
