### PR TITLE
fix: add Type tag for resource grouping based on private networking 

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -382,6 +382,7 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2025-04-01' = {
   properties: {
     tags: union(existingTags, allTags, {
       TemplateName: 'CWYD'
+      Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
       CreatedBy: createdBy
     })
   }

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "12856068160787442197"
+      "templateHash": "112031933447881868"
     }
   },
   "parameters": {
@@ -698,7 +698,7 @@
       "apiVersion": "2025-04-01",
       "name": "default",
       "properties": {
-        "tags": "[union(variables('existingTags'), variables('allTags'), createObject('TemplateName', 'CWYD', 'CreatedBy', parameters('createdBy')))]"
+        "tags": "[union(variables('existingTags'), variables('allTags'), createObject('TemplateName', 'CWYD', 'Type', if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy')))]"
       }
     },
     "avmTelemetry": {


### PR DESCRIPTION
## Purpose
This pull request introduces a conditional tag assignment in the resource group tags to indicate whether private networking is enabled. The most important change is:

Added a new `Type` tag to resource group tags, which is set to `'WAF'` if `enablePrivateNetworking` is true, otherwise `'Non-WAF'`. This helps distinguish environments with private networking enabled.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No


## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
This pull request makes a small but important update to the tagging of resources in the infrastructure template. A new tag is added to distinguish between resources with private networking enabled and those without.

- Tagging enhancement:
  * In the `resourceGroupTags` resource in `infra/main.bicep`, a new `Type` tag is added. Its value is set to `'WAF'` if `enablePrivateNetworking` is true, otherwise `'Non-WAF'`, helping to categorize resources based on their networking configuration.

## What to Check
This pull request introduces a conditional tag assignment in the `resourceGroupTags` resource to better indicate the networking configuration of the deployment. The most important change is:

Tagging Improvements:
* Added a `Type` tag to the `tags` property in `resourceGroupTags`, which is set to `'WAF'` if `enablePrivateNetworking` is true, and `'Non-WAF'` otherwise. This helps distinguish between WAF-enabled and non-WAF deployments for resource groups.* ...

