### PR TITLE
fix: Update create-release.yml to update codfix

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
-      - uses: codfish/semantic-release-action@v4
+      - uses: codfish/semantic-release-action@da160b1641c06934ddd00715c6594be85acb5fce # v2.0.0
         id: semantic
         with:
           tag-format: 'v${version}'


### PR DESCRIPTION

## What to Check
Verify that the following are valid
* Exactly one `codfish/semantic-release-action` reference, pinned to the clean SHA with the `# v2.0.0` comment (repo convention: `@<sha> # vX.Y.Z`).
* No unsafe floating refs remain (`@v4`, `@v2`, `@v2.2.1`, `@v3`, `@v5`).
* `.releaserc.json` is removed and there is no `setup-node` / `npx` residue — the migration is fully reverted.
* `permissions` are unchanged (`contents: write`, `pull-requests: write`).

## Other Information
<!-- Add any other helpful information that may be needed here. -->
* **Runtime caveat:** the upstream `codfish/semantic-release-action` repository is currently GitHub-disabled, so any pin (SHA or tag) cannot be fetched at runtime — `Create-Release` will fail until the action is replaced or re-enabled. This PR restores supply-chain safety; a follow-up is required to make the release pipeline functional again.
* **Operational follow-ups (out of scope here):** audit `Create-Release` run/release/tag/PR history for any prior `@v4` execution. Only `GITHUB_TOKEN` (per-job, auto-expiring) was reachable by this step — no long-lived secrets were exposed.