### PR TITLE
fix: codefish - added comment in raise exception

### DIFF
--- a/code/backend/api/chat_history.py
+++ b/code/backend/api/chat_history.py
@@ -293,6 +293,7 @@ async def delete_conversation():
             await conversation_client.close()
 
     except Exception as e:
+        # Log the exception and return a generic error message
         logger.exception(f"Exception in /history/delete: {e}")
         return jsonify({"error": "Error while deleting conversation history"}), 500
 


### PR DESCRIPTION
## Purpose
This pull request makes a small improvement to the error handling in the `delete_conversation` endpoint. Now, exceptions are explicitly logged with a comment, and a generic error message is returned to the client.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

## What to Check
Verify the pipeline