### PR TITLE
fix: Update ACR SKU and export policy based on networking settings

### DIFF
--- a/code/backend/Admin.py
+++ b/code/backend/Admin.py
@@ -63,7 +63,7 @@ def load_css(file_path):
         st.markdown(f"<style>{f.read()}</style>", unsafe_allow_html=True)
 
 
-# Load the common CSS
+# Load shared CSS styles.
 load_css("pages/common.css")
 
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1324,9 +1324,12 @@ module containerRegistry 'br/public:avm/res/container-registry/registry:0.9.1' =
     location: location
     tags: allTags
     enableTelemetry: enableTelemetry
-    acrSku: enableScalability || enableRedundancy ? 'Standard' : 'Basic'
+    acrSku: enablePrivateNetworking || enableScalability || enableRedundancy ? 'Premium' : 'Standard'
     acrAdminUserEnabled: false
     publicNetworkAccess: enablePrivateNetworking ? 'Disabled' : 'Enabled'
+    // Export policy can only be disabled when public network access is also disabled.
+    // Align it with the network mode to avoid DisableExport_PublicNetworkAccessMustBeDisabled.
+    exportPolicyStatus: enablePrivateNetworking ? 'disabled' : 'enabled'
     roleAssignments: [
       {
         // AcrPull: allows the managed identity to pull images from this registry at runtime


### PR DESCRIPTION
## Purpose
This pull request updates the configuration logic for the container registry in `infra/main.bicep` to better align SKU selection and export policy with network settings. The most important changes are:

Container Registry Configuration:

* Updated the `acrSku` selection logic to use `Premium` when private networking is enabled, in addition to scalability or redundancy, otherwise defaulting to `Standard`. This ensures the registry has the necessary features for private networking scenarios.
* Added `exportPolicyStatus` to automatically disable export policy when private networking is enabled, preventing misconfiguration and aligning with Azure requirements.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [X] Yes
- [ ] No

## Other Information
This pull request updates the configuration for the container registry deployment in `infra/main.bicep` to enhance security and compliance with Azure requirements. The main changes involve adjusting the SKU selection logic and export policy to better align with private networking and scalability needs.

**Container Registry Configuration Updates:**

* The `acrSku` selection now chooses `Premium` if private networking, scalability, or redundancy is enabled, otherwise defaults to `Standard`. Previously, it only considered scalability or redundancy and defaulted to `Basic`.
* The `exportPolicyStatus` is now explicitly set to `disabled` when private networking is enabled, and `enabled` otherwise. This ensures compliance with Azure's requirement that export policy can only be disabled when public network access is also disabled.