### PR TITLE
fix: Cursor and Agent response issue fixes

### DIFF
--- a/src/frontend/src/pages/chat/components/MessageInput.tsx
+++ b/src/frontend/src/pages/chat/components/MessageInput.tsx
@@ -95,6 +95,12 @@ export function MessageInput() {
   // on top of already-typed text instead of replacing it.
   const baseDraftRef = useRef("");
 
+  // The text field is disabled while a stream is in flight, which drops
+  // focus. Hold a ref so focus can be returned to the field once the
+  // stream finishes and the input re-enables, letting the user type the
+  // next question without clicking back into the box.
+  const inputRef = useRef<HTMLInputElement>(null);
+
   // Holds the AbortController for the in-flight stream so the Cancel
   // button can abort it. Cleared in the submit `finally` so a stale
   // controller can't fire a no-op abort against a closed stream.
@@ -107,6 +113,15 @@ export function MessageInput() {
     const separator = base.length > 0 && transcript.length > 0 ? " " : "";
     setDraft(base + separator + transcript);
   }, [speech.isListening, speech.transcript]);
+
+  // Return focus to the text field once the stream ends and dictation is
+  // idle, so the field re-enables under the cursor and the user can type
+  // the next question immediately.
+  useEffect(() => {
+    if (!isStreaming && !speech.isListening) {
+      inputRef.current?.focus();
+    }
+  }, [isStreaming, speech.isListening]);
 
   const trimmed = draft.trim();
   const canSend =
@@ -267,6 +282,7 @@ export function MessageInput() {
         Message
       </label>
       <input
+        ref={inputRef}
         id="message-input-field"
         type="text"
         value={draft}

--- a/src/functions/core/parsers/document_intelligence_parser.py
+++ b/src/functions/core/parsers/document_intelligence_parser.py
@@ -23,7 +23,10 @@ normalised to one trailing slash. Auth is UAMI bearer for
 
 Chunking strategy -- paginated formats (PDF, images) emit one ``Chunk``
 per Document Intelligence page, joining ``page.lines[*].content`` with
-``\\n``; pages with no lines (or whitespace-only content) are skipped.
+``\n``. Detected tables also emit structured label/value rows in the same
+page chunk. Soft-wrapped numeric fragments inside one cell are rejoined so
+identifiers and dates retain their cell value. Pages with no lines or table
+rows are skipped.
 Office and HTML formats (DOCX, PPTX, XLSX, HTML) are "pageless" -- the
 service returns their text in ``result.paragraphs`` and leaves
 ``page.lines`` empty, so when the page pass yields nothing the parser
@@ -59,6 +62,24 @@ logger = logging.getLogger(__name__)
 # a large document yields retrieval-friendly chunks instead of thousands of
 # sub-sentence ones.
 _FALLBACK_CHUNK_TARGET_CHARS = 2000
+
+
+def _rejoin_wrapped_cell(content: str) -> str:
+    """Collapse a soft-wrapped value inside a table cell.
+
+    Document Intelligence joins the visual lines of a wrapped cell value with a
+    space (e.g. ``"MA23000000424 7"``). Fragments are rejoined only where both
+    sides of the break are digits, so an identifier or number split across lines
+    is restored while ordinary word spacing (``"Chassis 19,000"``) is kept.
+    """
+    tokens = content.split()
+    if not tokens:
+        return ""
+    normalized = tokens[0]
+    for token in tokens[1:]:
+        separator = "" if normalized[-1].isdigit() and token[0].isdigit() else " "
+        normalized = f"{normalized}{separator}{token}"
+    return normalized
 
 
 @registry.register(ParserKey.DOCX)
@@ -132,10 +153,64 @@ class DocumentIntelligenceParser(BaseParser):
 
         chunks: list[Chunk] = []
         index = 0
-        for page in result.pages or []:
+        for page_position, page in enumerate(result.pages or [], start=1):
+            page_number = getattr(page, "page_number", page_position)
+            table_rows: list[str] = []
+            covered_ranges: list[tuple[int, int]] = []
+            for table in result.tables or []:
+                if not any(
+                    region.page_number == page_number
+                    for region in (table.bounding_regions or [])
+                ):
+                    continue
+
+                rows = [
+                    ["" for _ in range(table.column_count)]
+                    for _ in range(table.row_count)
+                ]
+                for cell in table.cells or []:
+                    for span in cell.spans or []:
+                        covered_ranges.append((span.offset, span.offset + span.length))
+                    normalized = _rejoin_wrapped_cell(cell.content or "")
+                    if normalized:
+                        rows[cell.row_index][cell.column_index] = normalized
+
+                for row in rows:
+                    fields: list[str] = []
+                    column_index = 0
+                    while column_index < len(row):
+                        value = row[column_index]
+                        if value.endswith(":") and column_index + 1 < len(row):
+                            paired_value = row[column_index + 1]
+                            fields.append(f"{value} {paired_value}".rstrip())
+                            column_index += 2
+                            continue
+                        if value:
+                            fields.append(value)
+                        column_index += 1
+                    if fields:
+                        table_rows.append(" | ".join(fields))
+
+            # Drop raw page lines that a table cell already covers (matched by
+            # character span); otherwise soft-wrapped cell values reappear split.
             page_text = "\n".join(
-                line.content for line in (page.lines or []) if line.content
+                line.content
+                for line in (page.lines or [])
+                if line.content
+                and not any(
+                    span.offset < cell_end and cell_start < span.offset + span.length
+                    for span in (line.spans or [])
+                    for cell_start, cell_end in covered_ranges
+                )
             ).strip()
+
+            if table_rows:
+                structured_tables = "\n".join(table_rows)
+                page_text = (
+                    f"{page_text}\n\nStructured table:\n{structured_tables}"
+                    if page_text
+                    else f"Structured table:\n{structured_tables}"
+                )
             if not page_text:
                 continue
             chunks.append(

--- a/tests/frontend/pages/chat/components/MessageInput.test.tsx
+++ b/tests/frontend/pages/chat/components/MessageInput.test.tsx
@@ -181,6 +181,17 @@ describe("MessageInput (preserved behavior)", () => {
     expect(probeMessages()).toEqual([]);
     expect(streamChatMock).not.toHaveBeenCalled();
   });
+
+  it("returns focus to the input after the stream finishes", async () => {
+    renderInput();
+    const field = getField();
+    await submit("hello world");
+
+    await waitFor(() => {
+      expect(field).not.toBeDisabled();
+    });
+    expect(document.activeElement).toBe(field);
+  });
 });
 
 describe("MessageInput SSE wiring", () => {

--- a/tests/functions/core/parsers/test_document_intelligence_parser.py
+++ b/tests/functions/core/parsers/test_document_intelligence_parser.py
@@ -48,6 +48,16 @@ def _make_fake_paragraph(content: str | None) -> SimpleNamespace:
 
 
 def _make_fake_client_with_result(result: Any) -> MagicMock:
+    if not hasattr(result, "tables"):
+        result.tables = None
+    for page in getattr(result, "pages", None) or []:
+        for line in getattr(page, "lines", None) or []:
+            if not hasattr(line, "spans"):
+                line.spans = []
+    for table in result.tables or []:
+        for cell in getattr(table, "cells", None) or []:
+            if not hasattr(cell, "spans"):
+                cell.spans = []
     poller = MagicMock()
     poller.result = AsyncMock(return_value=result)
     client = MagicMock()
@@ -249,6 +259,222 @@ async def test_parse_returns_one_chunk_per_page_with_deterministic_ids() -> None
             index=1,
         ),
     ]
+
+
+@pytest.mark.asyncio
+async def test_parse_normalizes_wrapped_identifier_in_table_cell() -> None:
+    def _line(content: str, offset: int, length: int) -> SimpleNamespace:
+        return SimpleNamespace(
+            content=content,
+            spans=[SimpleNamespace(offset=offset, length=length)],
+        )
+
+    def _cell(
+        row: int, column: int, content: str, offset: int, length: int
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            row_index=row,
+            column_index=column,
+            content=content,
+            spans=[SimpleNamespace(offset=offset, length=length)],
+        )
+
+    # Real Document Intelligence shape: the wrapped value lands in one cell as
+    # space-joined text, while the two visual fragments are separate lines.
+    fake_result = SimpleNamespace(
+        pages=[
+            SimpleNamespace(
+                page_number=1,
+                lines=[
+                    _line("State Contract Number:", 0, 22),
+                    _line("MA24000000466", 23, 13),
+                    _line("9", 37, 1),
+                    _line("Name:", 39, 5),
+                    _line("Propane", 45, 7),
+                ],
+            )
+        ],
+        tables=[
+            SimpleNamespace(
+                row_count=1,
+                column_count=4,
+                bounding_regions=[SimpleNamespace(page_number=1)],
+                cells=[
+                    _cell(0, 0, "State Contract Number:", 0, 22),
+                    _cell(0, 1, "MA24000000466 9", 23, 15),
+                    _cell(0, 2, "Name:", 39, 5),
+                    _cell(0, 3, "Propane", 45, 7),
+                ],
+            )
+        ],
+    )
+    parser = DocumentIntelligenceParser(
+        settings=_make_settings(),
+        credential=_make_credential(),
+        client=_make_fake_client_with_result(fake_result),
+    )
+
+    chunks = await parser.parse(b"...", source="propane.pdf")
+
+    assert "State Contract Number: MA240000004669" in chunks[0].content
+    assert "MA24000000466 9" not in chunks[0].content
+    assert "Name: Propane" in chunks[0].content
+
+
+@pytest.mark.asyncio
+async def test_parse_drops_table_covered_lines_so_wrapped_value_is_not_resplit() -> (
+    None
+):
+    def _line(content: str, offset: int, length: int) -> SimpleNamespace:
+        return SimpleNamespace(
+            content=content,
+            spans=[SimpleNamespace(offset=offset, length=length)],
+        )
+
+    def _cell(
+        row: int, column: int, content: str, offset: int, length: int
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            row_index=row,
+            column_index=column,
+            content=content,
+            spans=[SimpleNamespace(offset=offset, length=length)],
+        )
+
+    fake_result = SimpleNamespace(
+        pages=[
+            SimpleNamespace(
+                page_number=1,
+                lines=[
+                    _line("State of Alabama", 0, 16),
+                    _line("State Contract Number:", 100, 22),
+                    _line("MA23000000424", 123, 13),
+                    _line("7", 137, 1),
+                    _line("Name:", 139, 5),
+                    _line("Southland Transportation Group", 145, 30),
+                ],
+            )
+        ],
+        tables=[
+            SimpleNamespace(
+                row_count=1,
+                column_count=4,
+                bounding_regions=[SimpleNamespace(page_number=1)],
+                cells=[
+                    _cell(0, 0, "State Contract Number:", 100, 22),
+                    _cell(0, 1, "MA23000000424 7", 123, 15),
+                    _cell(0, 2, "Name:", 139, 5),
+                    _cell(0, 3, "Southland Transportation Group", 145, 30),
+                ],
+            )
+        ],
+    )
+    parser = DocumentIntelligenceParser(
+        settings=_make_settings(),
+        credential=_make_credential(),
+        client=_make_fake_client_with_result(fake_result),
+    )
+
+    content = (await parser.parse(b"...", source="purchase.pdf"))[0].content
+
+    assert "MA230000004247" in content
+    assert "MA23000000424 7" not in content
+    assert "MA23000000424\n7" not in content
+    assert "State of Alabama" in content
+
+
+@pytest.mark.asyncio
+async def test_parse_keeps_space_at_letter_to_digit_wrap() -> None:
+    # A word followed by a number across a wrap (e.g. "Chassis" + "19,000")
+    # must keep its space; only digit-to-digit breaks collapse.
+    def _line(content: str, offset: int, length: int) -> SimpleNamespace:
+        return SimpleNamespace(
+            content=content,
+            spans=[SimpleNamespace(offset=offset, length=length)],
+        )
+
+    fake_result = SimpleNamespace(
+        pages=[
+            SimpleNamespace(
+                page_number=1,
+                lines=[
+                    _line("Chassis", 0, 7),
+                    _line("19,000", 8, 6),
+                ],
+            )
+        ],
+        tables=[
+            SimpleNamespace(
+                row_count=1,
+                column_count=1,
+                bounding_regions=[SimpleNamespace(page_number=1)],
+                cells=[
+                    SimpleNamespace(
+                        row_index=0,
+                        column_index=0,
+                        content="Chassis 19,000",
+                        spans=[SimpleNamespace(offset=0, length=14)],
+                    ),
+                ],
+            )
+        ],
+    )
+    parser = DocumentIntelligenceParser(
+        settings=_make_settings(),
+        credential=_make_credential(),
+        client=_make_fake_client_with_result(fake_result),
+    )
+
+    content = (await parser.parse(b"...", source="wrap.pdf"))[0].content
+
+    assert "Chassis 19,000" in content
+    assert "Chassis19,000" not in content
+
+
+@pytest.mark.asyncio
+async def test_parse_keeps_space_between_two_wrapped_words() -> None:
+    def _line(content: str, offset: int, length: int) -> SimpleNamespace:
+        return SimpleNamespace(
+            content=content,
+            spans=[SimpleNamespace(offset=offset, length=length)],
+        )
+
+    fake_result = SimpleNamespace(
+        pages=[
+            SimpleNamespace(
+                page_number=1,
+                lines=[
+                    _line("Master", 0, 6),
+                    _line("Agreement", 7, 9),
+                ],
+            )
+        ],
+        tables=[
+            SimpleNamespace(
+                row_count=1,
+                column_count=1,
+                bounding_regions=[SimpleNamespace(page_number=1)],
+                cells=[
+                    SimpleNamespace(
+                        row_index=0,
+                        column_index=0,
+                        content="Master Agreement",
+                        spans=[SimpleNamespace(offset=0, length=16)],
+                    ),
+                ],
+            )
+        ],
+    )
+    parser = DocumentIntelligenceParser(
+        settings=_make_settings(),
+        credential=_make_credential(),
+        client=_make_fake_client_with_result(fake_result),
+    )
+
+    content = (await parser.parse(b"...", source="words.pdf"))[0].content
+
+    assert "Master Agreement" in content
+    assert "MasterAgreement" not in content
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request introduces improvements to both the frontend chat input experience and the backend document parsing logic. On the frontend, the message input field now automatically regains focus after a message stream completes, enhancing usability. On the backend, the document parser for paginated formats (like PDFs) has been enhanced to better handle structured tables, specifically by normalizing wrapped numeric identifiers in table cells and preventing duplicate or split values. Comprehensive tests were added to validate these behaviors.

Frontend usability improvements:
* The chat input field (`MessageInput.tsx`) now automatically regains focus after a streaming response finishes, so users can continue typing without manually clicking the field. [[1]](diffhunk://#diff-5b8ee8a239ac9cdec75c5c8b120e68eaaa92297748fd76087f1a0129c2d7ed6eR98-R103) [[2]](diffhunk://#diff-5b8ee8a239ac9cdec75c5c8b120e68eaaa92297748fd76087f1a0129c2d7ed6eR117-R125) [[3]](diffhunk://#diff-5b8ee8a239ac9cdec75c5c8b120e68eaaa92297748fd76087f1a0129c2d7ed6eR285) [[4]](diffhunk://#diff-e4638db6e1adfd65047c47d04fa9bcd3f1aeff466009de83c6cbfffe73fb9d21R184-R194)

Backend document parsing enhancements:
* The document intelligence parser now emits structured table rows alongside page text, normalizes soft-wrapped numeric identifiers in table cells (so IDs and dates aren't split), and skips lines already covered by table cells to avoid duplicate or split values. [[1]](diffhunk://#diff-c3abb40e1755682579bd743d2b52160c1d84f8142cb217248e954e01f63b7027L26-R29) [[2]](diffhunk://#diff-c3abb40e1755682579bd743d2b52160c1d84f8142cb217248e954e01f63b7027R67-R84) [[3]](diffhunk://#diff-c3abb40e1755682579bd743d2b52160c1d84f8142cb217248e954e01f63b7027L135-R213)
* Several new tests were added to ensure correct normalization of wrapped identifiers, proper handling of table-covered lines, and preservation of spaces in non-numeric wraps.
* The test harness was updated to ensure test data always includes expected attributes for tables and lines.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
