### PR TITLE
fix: speech service issue fix for WAF

### DIFF
--- a/infra/avm/main.bicep
+++ b/infra/avm/main.bicep
@@ -650,6 +650,9 @@ module aiProjectPrivateEndpoint './modules/networking/private-endpoint.bicep' = 
   }
 }
 
+// The Web socket from front end application connects to Speech service over a public internet and it does not work over a Private endpoint.
+// So public access is enabled even if AVM WAF is enabled.
+var enablePrivateNetworkingSpeech = false
 module speechService './modules/ai/ai-services.bicep' = {
   name: take('module.ai-services.SpeechServices.${solutionName}', 64)
   params: {
@@ -660,7 +663,7 @@ module speechService './modules/ai/ai-services.bicep' = {
     tags: allTags
     enableTelemetry: enableTelemetry
     kind: 'SpeechServices'
-    publicNetworkAccess: enablePrivateNetworking ? 'Disabled' : 'Enabled'
+    publicNetworkAccess: enablePrivateNetworkingSpeech ? 'Disabled' : 'Enabled'
     diagnosticSettings: monitoringDiagnosticSettings
     roleAssignments: [
       {
@@ -670,7 +673,7 @@ module speechService './modules/ai/ai-services.bicep' = {
         roleDefinitionIdOrName: 'f2dc8367-1007-4938-bd23-fe263f013447'
       }
     ]
-    privateEndpoints: enablePrivateNetworking
+    privateEndpoints: enablePrivateNetworkingSpeech
       ? [
           {
             name: 'pep-spch-${solutionSuffix}'

--- a/infra/avm/main.json
+++ b/infra/avm/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.45.15.27210",
-      "templateHash": "12270433528816504082"
+      "version": "0.46.1.21595",
+      "templateHash": "9141985131231540814"
     }
   },
   "parameters": {
@@ -384,6 +384,7 @@
     "virtualMachineAvailabilityZone": 1,
     "aiFoundryResourceGroupName": "[if(variables('useExistingAIProject'), split(parameters('existingFoundryProjectResourceId'), '/')[4], resourceGroup().name)]",
     "aiFoundrySubscriptionId": "[if(variables('useExistingAIProject'), split(parameters('existingFoundryProjectResourceId'), '/')[2], subscription().subscriptionId)]",
+    "enablePrivateNetworkingSpeech": false,
     "indexStoreValue": "[if(variables('isCosmos'), 'AzureSearch', 'pgvector')]"
   },
   "resources": {
@@ -453,8 +454,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "11785570845697058733"
+              "version": "0.46.1.21595",
+              "templateHash": "12857967541128499898"
             }
           },
           "parameters": {
@@ -1073,8 +1074,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "8088039885965286237"
+              "version": "0.46.1.21595",
+              "templateHash": "5005969515455354504"
             }
           },
           "parameters": {
@@ -4375,8 +4376,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "17593462233384180904"
+              "version": "0.46.1.21595",
+              "templateHash": "1077806126224374403"
             }
           },
           "parameters": {
@@ -5302,8 +5303,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "6921094249231590534"
+              "version": "0.46.1.21595",
+              "templateHash": "9667538828010425196"
             }
           },
           "definitions": {
@@ -8149,8 +8150,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "5843178535659210113"
+              "version": "0.46.1.21595",
+              "templateHash": "4613446280405157854"
             }
           },
           "parameters": {
@@ -10053,8 +10054,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "1089854782656841223"
+              "version": "0.46.1.21595",
+              "templateHash": "8420279536133240728"
             }
           },
           "parameters": {
@@ -10592,8 +10593,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "8930408375182742451"
+              "version": "0.46.1.21595",
+              "templateHash": "14701803776432038764"
             }
           },
           "parameters": {
@@ -12061,8 +12062,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "9515837065104451474"
+              "version": "0.46.1.21595",
+              "templateHash": "13006336383696924611"
             }
           },
           "parameters": {
@@ -12578,8 +12579,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "18103466400870370455"
+              "version": "0.46.1.21595",
+              "templateHash": "17976113817590025731"
             }
           },
           "parameters": {
@@ -21934,8 +21935,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "6776150673571028467"
+              "version": "0.46.1.21595",
+              "templateHash": "11076758087490966511"
             }
           },
           "parameters": {
@@ -25417,8 +25418,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "13279543274194444884"
+              "version": "0.46.1.21595",
+              "templateHash": "8266777043110372909"
             }
           },
           "parameters": {
@@ -25549,8 +25550,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "15082066787887503864"
+              "version": "0.46.1.21595",
+              "templateHash": "1404548925503916335"
             }
           },
           "definitions": {
@@ -28703,8 +28704,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "3303748358923315881"
+              "version": "0.46.1.21595",
+              "templateHash": "5315493943580072668"
             }
           },
           "parameters": {
@@ -28866,8 +28867,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "13058032099310447838"
+              "version": "0.46.1.21595",
+              "templateHash": "14933983914799613850"
             }
           },
           "parameters": {
@@ -29618,7 +29619,7 @@
           "kind": {
             "value": "SpeechServices"
           },
-          "publicNetworkAccess": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
+          "publicNetworkAccess": "[if(variables('enablePrivateNetworkingSpeech'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
           "diagnosticSettings": "[if(parameters('enableMonitoring'), createObject('value', createArray(createObject('workspaceResourceId', if(variables('useExistingLogAnalytics'), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('existingLogAnalyticsWorkspaceId'), '/')[2], split(parameters('existingLogAnalyticsWorkspaceId'), '/')[4]), 'Microsoft.OperationalInsights/workspaces', split(parameters('existingLogAnalyticsWorkspaceId'), '/')[8]), if(parameters('enableMonitoring'), reference('logAnalyticsWorkspace').outputs.resourceId.value, ''))))), createObject('value', createArray()))]",
           "roleAssignments": {
             "value": [
@@ -29629,7 +29630,7 @@
               }
             ]
           },
-          "privateEndpoints": "[if(parameters('enablePrivateNetworking'), createObject('value', createArray(createObject('name', format('pep-spch-{0}', variables('solutionSuffix')), 'customNetworkInterfaceName', format('nic-spch-{0}', variables('solutionSuffix')), 'subnetResourceId', reference('virtualNetwork').outputs.backendSubnetResourceId.value, 'service', 'account', 'privateDnsZoneGroup', createObject('privateDnsZoneGroupConfigs', createArray(createObject('name', 'cognitiveservices', 'privateDnsZoneResourceId', reference(format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').cognitiveServices)).outputs.resourceId.value)))))), createObject('value', createArray()))]"
+          "privateEndpoints": "[if(variables('enablePrivateNetworkingSpeech'), createObject('value', createArray(createObject('name', format('pep-spch-{0}', variables('solutionSuffix')), 'customNetworkInterfaceName', format('nic-spch-{0}', variables('solutionSuffix')), 'subnetResourceId', reference('virtualNetwork').outputs.backendSubnetResourceId.value, 'service', 'account', 'privateDnsZoneGroup', createObject('privateDnsZoneGroupConfigs', createArray(createObject('name', 'cognitiveservices', 'privateDnsZoneResourceId', reference(format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').cognitiveServices)).outputs.resourceId.value)))))), createObject('value', createArray()))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -29638,8 +29639,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "9262552868271250054"
+              "version": "0.46.1.21595",
+              "templateHash": "12286887912605258818"
             }
           },
           "definitions": {
@@ -32760,8 +32761,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "9262552868271250054"
+              "version": "0.46.1.21595",
+              "templateHash": "12286887912605258818"
             }
           },
           "definitions": {
@@ -35909,8 +35910,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "3890790255801604274"
+              "version": "0.46.1.21595",
+              "templateHash": "9004938137255842078"
             }
           },
           "parameters": {
@@ -38242,8 +38243,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "3215519417659672748"
+              "version": "0.46.1.21595",
+              "templateHash": "14116608463414189185"
             }
           },
           "parameters": {
@@ -38474,8 +38475,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "4431226019255775255"
+              "version": "0.46.1.21595",
+              "templateHash": "7118043580676261468"
             }
           },
           "definitions": {
@@ -47212,9 +47213,9 @@
       },
       "dependsOn": [
         "logAnalyticsWorkspace",
-        "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').file)]",
         "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').queue)]",
         "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').blob)]",
+        "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').file)]",
         "userAssignedIdentity",
         "virtualNetwork"
       ]
@@ -47277,8 +47278,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "14655724525550577174"
+              "version": "0.46.1.21595",
+              "templateHash": "2241271319035218760"
             }
           },
           "parameters": {
@@ -53506,8 +53507,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "5846678773431897698"
+              "version": "0.46.1.21595",
+              "templateHash": "5814913825796492187"
             }
           },
           "parameters": {
@@ -56638,8 +56639,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "12026204306075110528"
+              "version": "0.46.1.21595",
+              "templateHash": "15985718666368677061"
             }
           },
           "parameters": {
@@ -60737,8 +60738,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "1786125815674947096"
+              "version": "0.46.1.21595",
+              "templateHash": "2107246938672165393"
             }
           },
           "parameters": {
@@ -62161,8 +62162,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "17599168815727942183"
+              "version": "0.46.1.21595",
+              "templateHash": "9448190900735976715"
             }
           },
           "parameters": {
@@ -64033,8 +64034,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "17599168815727942183"
+              "version": "0.46.1.21595",
+              "templateHash": "9448190900735976715"
             }
           },
           "parameters": {
@@ -65900,8 +65901,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "17599168815727942183"
+              "version": "0.46.1.21595",
+              "templateHash": "9448190900735976715"
             }
           },
           "parameters": {
@@ -67765,8 +67766,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "15984063284559956915"
+              "version": "0.46.1.21595",
+              "templateHash": "14799966058260392271"
             }
           },
           "parameters": {
@@ -70637,8 +70638,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "15297330273700012534"
+              "version": "0.46.1.21595",
+              "templateHash": "7584327137625838503"
             }
           },
           "parameters": {

--- a/infra/bicep/main.json
+++ b/infra/bicep/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.45.15.27210",
-      "templateHash": "17591266640237568115"
+      "version": "0.46.1.21595",
+      "templateHash": "6491163985160595286"
     }
   },
   "parameters": {
@@ -345,8 +345,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "5391405737735698917"
+              "version": "0.46.1.21595",
+              "templateHash": "4217214652648169338"
             }
           },
           "parameters": {
@@ -446,8 +446,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "1562511690153284384"
+              "version": "0.46.1.21595",
+              "templateHash": "3561501102733674034"
             }
           },
           "parameters": {
@@ -578,8 +578,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "1396979465821863055"
+              "version": "0.46.1.21595",
+              "templateHash": "2461614014827306322"
             }
           },
           "parameters": {
@@ -739,8 +739,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "2061702784288856091"
+              "version": "0.46.1.21595",
+              "templateHash": "8348022486141626008"
             }
           },
           "parameters": {
@@ -866,8 +866,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "9158340857418869969"
+              "version": "0.46.1.21595",
+              "templateHash": "7677890268465434115"
             }
           },
           "parameters": {
@@ -1114,8 +1114,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "3303748358923315881"
+              "version": "0.46.1.21595",
+              "templateHash": "5315493943580072668"
             }
           },
           "parameters": {
@@ -1248,8 +1248,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "5129257976568532117"
+              "version": "0.46.1.21595",
+              "templateHash": "10850915666423951876"
             }
           },
           "parameters": {
@@ -1439,8 +1439,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "5129257976568532117"
+              "version": "0.46.1.21595",
+              "templateHash": "10850915666423951876"
             }
           },
           "parameters": {
@@ -1625,8 +1625,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "17915224445383853819"
+              "version": "0.46.1.21595",
+              "templateHash": "10009140357497945010"
             }
           },
           "parameters": {
@@ -1814,8 +1814,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "3599592075727945573"
+                      "version": "0.46.1.21595",
+                      "templateHash": "490514611876211300"
                     }
                   },
                   "parameters": {
@@ -2033,8 +2033,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "3215519417659672748"
+              "version": "0.46.1.21595",
+              "templateHash": "14116608463414189185"
             }
           },
           "parameters": {
@@ -2209,8 +2209,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "4181428258858303885"
+              "version": "0.46.1.21595",
+              "templateHash": "11406955295990414545"
             }
           },
           "parameters": {
@@ -2467,8 +2467,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "183685311511410868"
+              "version": "0.46.1.21595",
+              "templateHash": "6242014898061728245"
             }
           },
           "parameters": {
@@ -2686,8 +2686,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "10348311396020817822"
+              "version": "0.46.1.21595",
+              "templateHash": "14203486816443773061"
             }
           },
           "parameters": {
@@ -2962,8 +2962,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "17394234730827433787"
+              "version": "0.46.1.21595",
+              "templateHash": "3583897403640813084"
             }
           },
           "parameters": {
@@ -3164,8 +3164,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "4011306878782005340"
+              "version": "0.46.1.21595",
+              "templateHash": "3602507280793105823"
             }
           },
           "parameters": {
@@ -3358,8 +3358,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "211022699849388763"
+              "version": "0.46.1.21595",
+              "templateHash": "2155495949859131071"
             }
           },
           "parameters": {
@@ -3657,8 +3657,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "211022699849388763"
+              "version": "0.46.1.21595",
+              "templateHash": "2155495949859131071"
             }
           },
           "parameters": {
@@ -3951,8 +3951,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "211022699849388763"
+              "version": "0.46.1.21595",
+              "templateHash": "2155495949859131071"
             }
           },
           "parameters": {
@@ -4208,8 +4208,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "11772422603609590132"
+              "version": "0.46.1.21595",
+              "templateHash": "12565496040172867825"
             }
           },
           "parameters": {
@@ -4369,8 +4369,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "13516959090498150239"
+              "version": "0.46.1.21595",
+              "templateHash": "3911977498022884442"
             }
           },
           "parameters": {
@@ -4658,8 +4658,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "6381374613030863702"
+                      "version": "0.46.1.21595",
+                      "templateHash": "13837304634713780607"
                     }
                   },
                   "parameters": {
@@ -4782,8 +4782,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "2360502060837083798"
+              "version": "0.46.1.21595",
+              "templateHash": "2842689537252704390"
             }
           },
           "parameters": {

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.45.15.27210",
-      "templateHash": "17948190337731856959"
+      "version": "0.46.1.21595",
+      "templateHash": "11594359438356913742"
     },
     "name": "Chat With Your Data v2",
     "description": "Foundry-first RAG accelerator. Single databaseType parameter selects chat history + vector index. Two orchestrators (Agent Framework, LangGraph) on a shared Foundry Project."
@@ -479,8 +479,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "1019599034745970786"
+              "version": "0.46.1.21595",
+              "templateHash": "9141985131231540814"
             }
           },
           "parameters": {
@@ -858,6 +858,7 @@
             "virtualMachineAvailabilityZone": 1,
             "aiFoundryResourceGroupName": "[if(variables('useExistingAIProject'), split(parameters('existingFoundryProjectResourceId'), '/')[4], resourceGroup().name)]",
             "aiFoundrySubscriptionId": "[if(variables('useExistingAIProject'), split(parameters('existingFoundryProjectResourceId'), '/')[2], subscription().subscriptionId)]",
+            "enablePrivateNetworkingSpeech": false,
             "indexStoreValue": "[if(variables('isCosmos'), 'AzureSearch', 'pgvector')]"
           },
           "resources": {
@@ -927,8 +928,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "11785570845697058733"
+                      "version": "0.46.1.21595",
+                      "templateHash": "12857967541128499898"
                     }
                   },
                   "parameters": {
@@ -1547,8 +1548,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "8088039885965286237"
+                      "version": "0.46.1.21595",
+                      "templateHash": "5005969515455354504"
                     }
                   },
                   "parameters": {
@@ -4849,8 +4850,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "17593462233384180904"
+                      "version": "0.46.1.21595",
+                      "templateHash": "1077806126224374403"
                     }
                   },
                   "parameters": {
@@ -5776,8 +5777,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "6921094249231590534"
+                      "version": "0.46.1.21595",
+                      "templateHash": "9667538828010425196"
                     }
                   },
                   "definitions": {
@@ -8623,8 +8624,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "5843178535659210113"
+                      "version": "0.46.1.21595",
+                      "templateHash": "4613446280405157854"
                     }
                   },
                   "parameters": {
@@ -10527,8 +10528,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "1089854782656841223"
+                      "version": "0.46.1.21595",
+                      "templateHash": "8420279536133240728"
                     }
                   },
                   "parameters": {
@@ -11066,8 +11067,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "8930408375182742451"
+                      "version": "0.46.1.21595",
+                      "templateHash": "14701803776432038764"
                     }
                   },
                   "parameters": {
@@ -12535,8 +12536,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "9515837065104451474"
+                      "version": "0.46.1.21595",
+                      "templateHash": "13006336383696924611"
                     }
                   },
                   "parameters": {
@@ -13052,8 +13053,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "18103466400870370455"
+                      "version": "0.46.1.21595",
+                      "templateHash": "17976113817590025731"
                     }
                   },
                   "parameters": {
@@ -22408,8 +22409,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "6776150673571028467"
+                      "version": "0.46.1.21595",
+                      "templateHash": "11076758087490966511"
                     }
                   },
                   "parameters": {
@@ -25891,8 +25892,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "13279543274194444884"
+                      "version": "0.46.1.21595",
+                      "templateHash": "8266777043110372909"
                     }
                   },
                   "parameters": {
@@ -26023,8 +26024,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "15082066787887503864"
+                      "version": "0.46.1.21595",
+                      "templateHash": "1404548925503916335"
                     }
                   },
                   "definitions": {
@@ -29177,8 +29178,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "3303748358923315881"
+                      "version": "0.46.1.21595",
+                      "templateHash": "5315493943580072668"
                     }
                   },
                   "parameters": {
@@ -29340,8 +29341,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "13058032099310447838"
+                      "version": "0.46.1.21595",
+                      "templateHash": "14933983914799613850"
                     }
                   },
                   "parameters": {
@@ -30092,7 +30093,7 @@
                   "kind": {
                     "value": "SpeechServices"
                   },
-                  "publicNetworkAccess": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
+                  "publicNetworkAccess": "[if(variables('enablePrivateNetworkingSpeech'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
                   "diagnosticSettings": "[if(parameters('enableMonitoring'), createObject('value', createArray(createObject('workspaceResourceId', if(variables('useExistingLogAnalytics'), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('existingLogAnalyticsWorkspaceId'), '/')[2], split(parameters('existingLogAnalyticsWorkspaceId'), '/')[4]), 'Microsoft.OperationalInsights/workspaces', split(parameters('existingLogAnalyticsWorkspaceId'), '/')[8]), if(parameters('enableMonitoring'), reference('logAnalyticsWorkspace').outputs.resourceId.value, ''))))), createObject('value', createArray()))]",
                   "roleAssignments": {
                     "value": [
@@ -30103,7 +30104,7 @@
                       }
                     ]
                   },
-                  "privateEndpoints": "[if(parameters('enablePrivateNetworking'), createObject('value', createArray(createObject('name', format('pep-spch-{0}', variables('solutionSuffix')), 'customNetworkInterfaceName', format('nic-spch-{0}', variables('solutionSuffix')), 'subnetResourceId', reference('virtualNetwork').outputs.backendSubnetResourceId.value, 'service', 'account', 'privateDnsZoneGroup', createObject('privateDnsZoneGroupConfigs', createArray(createObject('name', 'cognitiveservices', 'privateDnsZoneResourceId', reference(format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').cognitiveServices)).outputs.resourceId.value)))))), createObject('value', createArray()))]"
+                  "privateEndpoints": "[if(variables('enablePrivateNetworkingSpeech'), createObject('value', createArray(createObject('name', format('pep-spch-{0}', variables('solutionSuffix')), 'customNetworkInterfaceName', format('nic-spch-{0}', variables('solutionSuffix')), 'subnetResourceId', reference('virtualNetwork').outputs.backendSubnetResourceId.value, 'service', 'account', 'privateDnsZoneGroup', createObject('privateDnsZoneGroupConfigs', createArray(createObject('name', 'cognitiveservices', 'privateDnsZoneResourceId', reference(format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').cognitiveServices)).outputs.resourceId.value)))))), createObject('value', createArray()))]"
                 },
                 "template": {
                   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -30112,8 +30113,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "9262552868271250054"
+                      "version": "0.46.1.21595",
+                      "templateHash": "12286887912605258818"
                     }
                   },
                   "definitions": {
@@ -33234,8 +33235,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "9262552868271250054"
+                      "version": "0.46.1.21595",
+                      "templateHash": "12286887912605258818"
                     }
                   },
                   "definitions": {
@@ -36383,8 +36384,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "3890790255801604274"
+                      "version": "0.46.1.21595",
+                      "templateHash": "9004938137255842078"
                     }
                   },
                   "parameters": {
@@ -38716,8 +38717,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "3215519417659672748"
+                      "version": "0.46.1.21595",
+                      "templateHash": "14116608463414189185"
                     }
                   },
                   "parameters": {
@@ -38948,8 +38949,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "4431226019255775255"
+                      "version": "0.46.1.21595",
+                      "templateHash": "7118043580676261468"
                     }
                   },
                   "definitions": {
@@ -47687,8 +47688,8 @@
               "dependsOn": [
                 "logAnalyticsWorkspace",
                 "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').queue)]",
-                "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').file)]",
                 "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').blob)]",
+                "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').file)]",
                 "userAssignedIdentity",
                 "virtualNetwork"
               ]
@@ -47751,8 +47752,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "14655724525550577174"
+                      "version": "0.46.1.21595",
+                      "templateHash": "2241271319035218760"
                     }
                   },
                   "parameters": {
@@ -53980,8 +53981,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "5846678773431897698"
+                      "version": "0.46.1.21595",
+                      "templateHash": "5814913825796492187"
                     }
                   },
                   "parameters": {
@@ -57112,8 +57113,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "12026204306075110528"
+                      "version": "0.46.1.21595",
+                      "templateHash": "15985718666368677061"
                     }
                   },
                   "parameters": {
@@ -61211,8 +61212,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "1786125815674947096"
+                      "version": "0.46.1.21595",
+                      "templateHash": "2107246938672165393"
                     }
                   },
                   "parameters": {
@@ -62635,8 +62636,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "17599168815727942183"
+                      "version": "0.46.1.21595",
+                      "templateHash": "9448190900735976715"
                     }
                   },
                   "parameters": {
@@ -64507,8 +64508,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "17599168815727942183"
+                      "version": "0.46.1.21595",
+                      "templateHash": "9448190900735976715"
                     }
                   },
                   "parameters": {
@@ -66374,8 +66375,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "17599168815727942183"
+                      "version": "0.46.1.21595",
+                      "templateHash": "9448190900735976715"
                     }
                   },
                   "parameters": {
@@ -68239,8 +68240,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "15984063284559956915"
+                      "version": "0.46.1.21595",
+                      "templateHash": "14799966058260392271"
                     }
                   },
                   "parameters": {
@@ -71111,8 +71112,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "15297330273700012534"
+                      "version": "0.46.1.21595",
+                      "templateHash": "7584327137625838503"
                     }
                   },
                   "parameters": {
@@ -71844,8 +71845,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.15.27210",
-              "templateHash": "17591266640237568115"
+              "version": "0.46.1.21595",
+              "templateHash": "6491163985160595286"
             }
           },
           "parameters": {
@@ -72184,8 +72185,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "5391405737735698917"
+                      "version": "0.46.1.21595",
+                      "templateHash": "4217214652648169338"
                     }
                   },
                   "parameters": {
@@ -72285,8 +72286,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "1562511690153284384"
+                      "version": "0.46.1.21595",
+                      "templateHash": "3561501102733674034"
                     }
                   },
                   "parameters": {
@@ -72417,8 +72418,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "1396979465821863055"
+                      "version": "0.46.1.21595",
+                      "templateHash": "2461614014827306322"
                     }
                   },
                   "parameters": {
@@ -72578,8 +72579,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "2061702784288856091"
+                      "version": "0.46.1.21595",
+                      "templateHash": "8348022486141626008"
                     }
                   },
                   "parameters": {
@@ -72705,8 +72706,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "9158340857418869969"
+                      "version": "0.46.1.21595",
+                      "templateHash": "7677890268465434115"
                     }
                   },
                   "parameters": {
@@ -72953,8 +72954,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "3303748358923315881"
+                      "version": "0.46.1.21595",
+                      "templateHash": "5315493943580072668"
                     }
                   },
                   "parameters": {
@@ -73087,8 +73088,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "5129257976568532117"
+                      "version": "0.46.1.21595",
+                      "templateHash": "10850915666423951876"
                     }
                   },
                   "parameters": {
@@ -73278,8 +73279,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "5129257976568532117"
+                      "version": "0.46.1.21595",
+                      "templateHash": "10850915666423951876"
                     }
                   },
                   "parameters": {
@@ -73464,8 +73465,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "17915224445383853819"
+                      "version": "0.46.1.21595",
+                      "templateHash": "10009140357497945010"
                     }
                   },
                   "parameters": {
@@ -73653,8 +73654,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.45.15.27210",
-                              "templateHash": "3599592075727945573"
+                              "version": "0.46.1.21595",
+                              "templateHash": "490514611876211300"
                             }
                           },
                           "parameters": {
@@ -73872,8 +73873,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "3215519417659672748"
+                      "version": "0.46.1.21595",
+                      "templateHash": "14116608463414189185"
                     }
                   },
                   "parameters": {
@@ -74048,8 +74049,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "4181428258858303885"
+                      "version": "0.46.1.21595",
+                      "templateHash": "11406955295990414545"
                     }
                   },
                   "parameters": {
@@ -74306,8 +74307,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "183685311511410868"
+                      "version": "0.46.1.21595",
+                      "templateHash": "6242014898061728245"
                     }
                   },
                   "parameters": {
@@ -74525,8 +74526,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "10348311396020817822"
+                      "version": "0.46.1.21595",
+                      "templateHash": "14203486816443773061"
                     }
                   },
                   "parameters": {
@@ -74801,8 +74802,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "17394234730827433787"
+                      "version": "0.46.1.21595",
+                      "templateHash": "3583897403640813084"
                     }
                   },
                   "parameters": {
@@ -75003,8 +75004,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "4011306878782005340"
+                      "version": "0.46.1.21595",
+                      "templateHash": "3602507280793105823"
                     }
                   },
                   "parameters": {
@@ -75197,8 +75198,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "211022699849388763"
+                      "version": "0.46.1.21595",
+                      "templateHash": "2155495949859131071"
                     }
                   },
                   "parameters": {
@@ -75496,8 +75497,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "211022699849388763"
+                      "version": "0.46.1.21595",
+                      "templateHash": "2155495949859131071"
                     }
                   },
                   "parameters": {
@@ -75790,8 +75791,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "211022699849388763"
+                      "version": "0.46.1.21595",
+                      "templateHash": "2155495949859131071"
                     }
                   },
                   "parameters": {
@@ -76047,8 +76048,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "11772422603609590132"
+                      "version": "0.46.1.21595",
+                      "templateHash": "12565496040172867825"
                     }
                   },
                   "parameters": {
@@ -76208,8 +76209,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "13516959090498150239"
+                      "version": "0.46.1.21595",
+                      "templateHash": "3911977498022884442"
                     }
                   },
                   "parameters": {
@@ -76497,8 +76498,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.45.15.27210",
-                              "templateHash": "6381374613030863702"
+                              "version": "0.46.1.21595",
+                              "templateHash": "13837304634713780607"
                             }
                           },
                           "parameters": {
@@ -76621,8 +76622,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.15.27210",
-                      "templateHash": "2360502060837083798"
+                      "version": "0.46.1.21595",
+                      "templateHash": "2842689537252704390"
                     }
                   },
                   "parameters": {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request updates the way private networking is configured for the Speech service in the Azure infrastructure templates. The main change is to decouple Speech service's private endpoint configuration from the global private networking setting, ensuring public access is enabled for Speech even when AVM WAF is on (since Speech WebSocket connections require public internet access). Additionally, the Bicep and generated ARM templates are updated to reflect this logic, and the Bicep compiler version is bumped.

**Speech Service Networking Configuration:**

* Introduced a new variable `enablePrivateNetworkingSpeech` in `main.bicep` and set it to `false` to ensure Speech service remains publicly accessible, regardless of the general private networking setting.
* Updated the Speech service module to use `enablePrivateNetworkingSpeech` for both `publicNetworkAccess` and `privateEndpoints`, decoupling it from the global `enablePrivateNetworking` variable. [[1]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfL663-R666) [[2]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfL673-R676)
* Reflected this logic in the generated ARM template (`main.json`), updating the corresponding parameters and variables for Speech service's networking. [[1]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fR387) [[2]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fL29621-R29622) [[3]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fL29632-R29633)

**Template and Tooling Updates:**

* Upgraded the Bicep compiler version from `0.45.15.27210` to `0.46.1.21595` across all template metadata, resulting in new `templateHash` values throughout the ARM template. ([infra/avm/main.jsonL8-R9](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fL8-R9) and multiple similar lines)
* Minor fix in resource dependency ordering in `main.json` for DNS zone deployments.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
