### PR TITLE
fix: update nanoid version to 3.3.18 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "minimatch@10.2.5": {
       "brace-expansion": "5.0.9"
     },
+    "nanoid": "3.3.18",
     "postcss": "8.5.25"
   }
 }


### PR DESCRIPTION
## Purpose
This pull request makes a minor update to the `package.json` file by adding the `nanoid` dependency at version 3.3.18.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

## Other Information
This pull request introduces a minor update to the project's dependencies by adding the `nanoid` package to `package.json`.

* Dependency update:
  * Added `nanoid` version 3.3.18 to the project dependencies in `package.json`.